### PR TITLE
[#7]feat: Daily challenge entity 생성

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/DailyAuth.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/DailyAuth.java
@@ -1,0 +1,37 @@
+package com.itoxi.petnuri.domain.dailychallenge;
+
+import com.itoxi.petnuri.global.common.BaseTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+/**
+ * author         : matrix
+ * date           : 2023-09-13
+ * description    :
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "daily_auth")
+public class DailyAuth extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "daily_auth_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_participate_id")
+    private DailyParticipate dailyParticipate;
+
+    @Column(nullable = false)
+    private String content;
+
+    // 기획안에 인증샷은 최대 1개로 되어 있어 인증샷 테이블 -> 인증글로 통합
+    @Column(nullable = false)
+    private String imgName; // 인증샹 파일명
+    @Column(nullable = false)
+    private String imgUrl;  // 인증샷 S3 url
+}

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/DailyChallenge.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/DailyChallenge.java
@@ -1,0 +1,43 @@
+package com.itoxi.petnuri.domain.dailychallenge;
+
+import com.itoxi.petnuri.global.common.BaseTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+/**
+ * author         : matrix
+ * date           : 2023-09-13
+ * description    :
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "daily_challenge")
+public class DailyChallenge extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "daily_challenge_id", nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;        // 챌린지명
+    @Column(nullable = false)
+    private String authMethod;  // 챌린지 인증 방법
+    @Column(nullable = false)
+    private Long payment;       // 챌린지 인증 완료시 지급 포인트
+
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime startDate;    // 챌린지 시작 일자 : 2023-09-12 00:00:00
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime endDate;      // 챌린지 종료 일자 : 2023-09-12 23:59:59
+
+    @OneToMany(mappedBy = "dailyChallenge")
+    private List<DailyParticipate> dailyParticipate = new ArrayList<>(); // 챌린지 참여 매핑
+
+}

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/DailyParticipate.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/DailyParticipate.java
@@ -1,0 +1,48 @@
+package com.itoxi.petnuri.domain.dailychallenge;
+
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.global.common.BaseTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+/**
+ * author         : matrix
+ * date           : 2023-09-13
+ * description    :
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "daily_participate")
+public class DailyParticipate extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "daily_participate_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_challenge_id")
+    private DailyChallenge dailyChallenge;  // 챌린지 참여
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Transient
+    private Boolean autoSave;  // 펫톡 게시판 자동 등록 여부
+
+    @Transient
+    private Boolean status;     // 인증글 작성 여부
+
+    @OneToMany(mappedBy = "dailyParticipate")
+    private List<DailyAuth> dailyAuthList = new ArrayList<>();
+
+}


### PR DESCRIPTION
## 요약
Daily challenge 관련 entity 생성

## 작업 내용
- Daily challenge 관련 entity 생성.
- PR 리뷰 내용 반영(카멜 케이스, @Column 애너테이션 적용).

## 참고 사항
- Daily challenge 인증 게시판과 Pet talk 게시판의 컬럼을 통일해야 할지, PetTalk 게시판 API에 맞게 dto로 변환해서 호출만 할지 논의가 필요함.

## 관련 이슈
Close #7 
