### PR TITLE
[#24] Feat: 펫톡 감정표현 등록/삭제 구현 

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/controller/PetTalkEmotionController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/controller/PetTalkEmotionController.java
@@ -3,6 +3,8 @@ package com.itoxi.petnuri.domain.petTalk.controller;
 import com.itoxi.petnuri.domain.member.entity.Member;
 import com.itoxi.petnuri.domain.petTalk.dto.request.CreatePetTalkEmotionReq;
 import com.itoxi.petnuri.domain.petTalk.service.PetTalkEmotionService;
+import com.itoxi.petnuri.domain.petTalk.type.EmojiType;
+import com.itoxi.petnuri.global.common.customValid.valid.ValidEnum;
 import com.itoxi.petnuri.global.common.customValid.valid.ValidId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,5 +27,16 @@ public class PetTalkEmotionController {
         Member member = principalDetails.getMember();
         petTalkEmotionService.create(member, petTalkId, request);
         return new ResponseEntity<>(null, HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/{petTalkId}/emotion")
+    public ResponseEntity<Object> delete(
+            @PathVariable @ValidId Long petTalkId,
+            @RequestParam @ValidEnum(enumClass = EmojiType.class) EmojiType emoji,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        Member member = principalDetails.getMember();
+        petTalkEmotionService.delete(member, petTalkId, emoji);
+        return new ResponseEntity<>(null, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/controller/PetTalkEmotionController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/controller/PetTalkEmotionController.java
@@ -1,0 +1,29 @@
+package com.itoxi.petnuri.domain.petTalk.controller;
+
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.domain.petTalk.dto.request.CreatePetTalkEmotionReq;
+import com.itoxi.petnuri.domain.petTalk.service.PetTalkEmotionService;
+import com.itoxi.petnuri.global.common.customValid.valid.ValidId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/pet-talk")
+@RequiredArgsConstructor
+public class PetTalkEmotionController {
+    private final PetTalkEmotionService petTalkEmotionService;
+
+    @PostMapping("/{petTalkId}/emotion")
+    public ResponseEntity<Object> create(
+            @PathVariable @ValidId Long petTalkId,
+            @RequestBody CreatePetTalkEmotionReq request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        Member member = principalDetails.getMember();
+        petTalkEmotionService.create(member, petTalkId, request);
+        return new ResponseEntity<>(null, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/dto/request/CreatePetTalkEmotionReq.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/dto/request/CreatePetTalkEmotionReq.java
@@ -1,0 +1,11 @@
+package com.itoxi.petnuri.domain.petTalk.dto.request;
+
+import com.itoxi.petnuri.domain.petTalk.type.EmojiType;
+import com.itoxi.petnuri.global.common.customValid.valid.ValidEnum;
+import lombok.Getter;
+
+@Getter
+public class CreatePetTalkEmotionReq {
+    @ValidEnum(enumClass = EmojiType.class)
+    EmojiType emoji;
+}

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/entity/PetTalkEmotion.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/entity/PetTalkEmotion.java
@@ -1,6 +1,7 @@
 package com.itoxi.petnuri.domain.petTalk.entity;
 
 import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.domain.petTalk.type.EmojiType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,9 +13,9 @@ import javax.persistence.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "pet_talk_like")
+@Table(name = "pet_talk_emotion")
 @Entity
-public class PetTalkLike {
+public class PetTalkEmotion {
     @Id
     @Column(name = "pet_talk_like_id", nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,4 +29,15 @@ public class PetTalkLike {
     @JoinColumn(name = "pet_talk_id")
     private PetTalk petTalk;
 
+    @Column(name = "emoji", nullable = false)
+    @Enumerated(EnumType.STRING)
+    EmojiType emoji;
+
+    public static PetTalkEmotion create(Member member, PetTalk petTalk, EmojiType emoji) {
+        return PetTalkEmotion.builder()
+                .member(member)
+                .petTalk(petTalk)
+                .emoji(emoji)
+                .build();
+    }
 }

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/repository/PetTalkEmotionRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/repository/PetTalkEmotionRepository.java
@@ -1,0 +1,11 @@
+package com.itoxi.petnuri.domain.petTalk.repository;
+
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.domain.petTalk.entity.PetTalk;
+import com.itoxi.petnuri.domain.petTalk.entity.PetTalkEmotion;
+import com.itoxi.petnuri.domain.petTalk.type.EmojiType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetTalkEmotionRepository extends JpaRepository<PetTalkEmotion, Long> {
+    boolean existsByMemberAndPetTalkAndEmoji(Member member, PetTalk petTalk, EmojiType emoji);
+}

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/repository/PetTalkEmotionRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/repository/PetTalkEmotionRepository.java
@@ -6,6 +6,10 @@ import com.itoxi.petnuri.domain.petTalk.entity.PetTalkEmotion;
 import com.itoxi.petnuri.domain.petTalk.type.EmojiType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PetTalkEmotionRepository extends JpaRepository<PetTalkEmotion, Long> {
     boolean existsByMemberAndPetTalkAndEmoji(Member member, PetTalk petTalk, EmojiType emoji);
+
+    Optional<PetTalkEmotion> findByMemberAndPetTalkAndEmoji(Member member, PetTalk petTalk, EmojiType emoji);
 }

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/service/PetTalkEmotionService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/service/PetTalkEmotionService.java
@@ -1,0 +1,31 @@
+package com.itoxi.petnuri.domain.petTalk.service;
+
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.domain.petTalk.dto.request.CreatePetTalkEmotionReq;
+import com.itoxi.petnuri.domain.petTalk.entity.PetTalk;
+import com.itoxi.petnuri.domain.petTalk.entity.PetTalkEmotion;
+import com.itoxi.petnuri.domain.petTalk.repository.PetTalkEmotionRepository;
+import com.itoxi.petnuri.domain.petTalk.repository.PetTalkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PetTalkEmotionService {
+    private final PetTalkRepository petTalkRepository;
+    private final PetTalkEmotionRepository petTalkEmotionRepository;
+
+    public void create(Member member, Long petTalkId, CreatePetTalkEmotionReq request) {
+        PetTalk petTalk = petTalkRepository.findById(petTalkId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다"));
+
+        // 중복 레코드 검사
+        boolean isExists = petTalkEmotionRepository.existsByMemberAndPetTalkAndEmoji(member, petTalk, request.getEmoji());
+        if (isExists) {
+            throw new RuntimeException("이미 등록된 데이터입니다.");
+        }
+
+        PetTalkEmotion petTalkEmotion = PetTalkEmotion.create(member, petTalk, request.getEmoji());
+        petTalkEmotionRepository.save(petTalkEmotion);
+    }
+}

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/service/PetTalkEmotionService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/service/PetTalkEmotionService.java
@@ -6,6 +6,7 @@ import com.itoxi.petnuri.domain.petTalk.entity.PetTalk;
 import com.itoxi.petnuri.domain.petTalk.entity.PetTalkEmotion;
 import com.itoxi.petnuri.domain.petTalk.repository.PetTalkEmotionRepository;
 import com.itoxi.petnuri.domain.petTalk.repository.PetTalkRepository;
+import com.itoxi.petnuri.domain.petTalk.type.EmojiType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,5 +28,15 @@ public class PetTalkEmotionService {
 
         PetTalkEmotion petTalkEmotion = PetTalkEmotion.create(member, petTalk, request.getEmoji());
         petTalkEmotionRepository.save(petTalkEmotion);
+    }
+
+    public void delete(Member member, Long petTalkId, EmojiType emoji) {
+        PetTalk petTalk = petTalkRepository.findById(petTalkId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다"));
+
+        PetTalkEmotion petTalkEmotion = petTalkEmotionRepository.findByMemberAndPetTalkAndEmoji(member, petTalk, emoji)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 데이터입니다."));
+        
+        petTalkEmotionRepository.delete(petTalkEmotion);
     }
 }

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/type/EmojiType.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/type/EmojiType.java
@@ -1,0 +1,9 @@
+package com.itoxi.petnuri.domain.petTalk.type;
+
+public enum EmojiType {
+    CUTE,
+    FUN,
+    KISS,
+    OMG,
+    SAD
+}

--- a/src/main/java/com/itoxi/petnuri/global/common/customValid/valid/ValidEnum.java
+++ b/src/main/java/com/itoxi/petnuri/global/common/customValid/valid/ValidEnum.java
@@ -1,0 +1,23 @@
+package com.itoxi.petnuri.global.common.customValid.valid;
+
+import com.itoxi.petnuri.global.common.customValid.validator.EnumValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+    String message() default "정의 되지 않은 입력 입니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends Enum<?>> enumClass();
+
+    boolean nullable() default false;
+}

--- a/src/main/java/com/itoxi/petnuri/global/common/customValid/validator/EnumValidator.java
+++ b/src/main/java/com/itoxi/petnuri/global/common/customValid/validator/EnumValidator.java
@@ -1,0 +1,36 @@
+package com.itoxi.petnuri.global.common.customValid.validator;
+
+import com.itoxi.petnuri.global.common.customValid.valid.ValidEnum;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
+    private ValidEnum annotation;
+
+    @Override
+    public void initialize(ValidEnum constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(Enum value, ConstraintValidatorContext context) {
+        boolean result = false;
+
+        boolean nullable = this.annotation.nullable();
+        if (nullable) {
+            return true;
+        }
+
+        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value == enumValue) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## 요약
펫톡 감정표현 등록/삭제 구현 

## 작업 내용
- [x]  반응 등록
- [x]  반응 삭제

## 참고 사항
Enum 에 대한 유효성 검사 어노테이션 @ValidEnum 커스텀하여 추가했습니다!

## 관련 이슈
Close #24
