### PR TITLE
[#36] fix: Member Entity 수정에 따른 펫톡 파트 오류 해결 

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/controller/PetTalkEmotionController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/controller/PetTalkEmotionController.java
@@ -1,42 +1,43 @@
-//package com.itoxi.petnuri.domain.petTalk.controller;
-//
-//import com.itoxi.petnuri.domain.member.entity.Member;
-//import com.itoxi.petnuri.domain.petTalk.dto.request.CreatePetTalkEmotionReq;
-//import com.itoxi.petnuri.domain.petTalk.service.PetTalkEmotionService;
-//import com.itoxi.petnuri.domain.petTalk.type.EmojiType;
-//import com.itoxi.petnuri.global.common.customValid.valid.ValidEnum;
-//import com.itoxi.petnuri.global.common.customValid.valid.ValidId;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.security.core.annotation.AuthenticationPrincipal;
-//import org.springframework.web.bind.annotation.*;
-//
-//@RestController
-//@RequestMapping("/pet-talk")
-//@RequiredArgsConstructor
-//public class PetTalkEmotionController {
-//    private final PetTalkEmotionService petTalkEmotionService;
-//
-//    @PostMapping("/{petTalkId}/emotion")
-//    public ResponseEntity<Object> create(
-//            @PathVariable @ValidId Long petTalkId,
-//            @RequestBody CreatePetTalkEmotionReq request,
-//            @AuthenticationPrincipal PrincipalDetails principalDetails
-//    ) {
-//        Member member = principalDetails.getMember();
-//        petTalkEmotionService.create(member, petTalkId, request);
-//        return new ResponseEntity<>(null, HttpStatus.CREATED);
-//    }
-//
-//    @DeleteMapping("/{petTalkId}/emotion")
-//    public ResponseEntity<Object> delete(
-//            @PathVariable @ValidId Long petTalkId,
-//            @RequestParam @ValidEnum(enumClass = EmojiType.class) EmojiType emoji,
-//            @AuthenticationPrincipal PrincipalDetails principalDetails
-//    ) {
-//        Member member = principalDetails.getMember();
-//        petTalkEmotionService.delete(member, petTalkId, emoji);
-//        return new ResponseEntity<>(null, HttpStatus.OK);
-//    }
-//}
+package com.itoxi.petnuri.domain.petTalk.controller;
+
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.domain.petTalk.dto.request.CreatePetTalkEmotionReq;
+import com.itoxi.petnuri.domain.petTalk.service.PetTalkEmotionService;
+import com.itoxi.petnuri.domain.petTalk.type.EmojiType;
+import com.itoxi.petnuri.global.common.customValid.valid.ValidEnum;
+import com.itoxi.petnuri.global.common.customValid.valid.ValidId;
+import com.itoxi.petnuri.global.security.auth.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/pet-talk")
+@RequiredArgsConstructor
+public class PetTalkEmotionController {
+    private final PetTalkEmotionService petTalkEmotionService;
+
+    @PostMapping("/{petTalkId}/emotion")
+    public ResponseEntity<Object> create(
+            @PathVariable @ValidId Long petTalkId,
+            @RequestBody CreatePetTalkEmotionReq request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        Member member = principalDetails.getMember();
+        petTalkEmotionService.create(member, petTalkId, request);
+        return new ResponseEntity<>(null, HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/{petTalkId}/emotion")
+    public ResponseEntity<Object> delete(
+            @PathVariable @ValidId Long petTalkId,
+            @RequestParam @ValidEnum(enumClass = EmojiType.class) EmojiType emoji,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        Member member = principalDetails.getMember();
+        petTalkEmotionService.delete(member, petTalkId, emoji);
+        return new ResponseEntity<>(null, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/controller/PetTalkReplyController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/controller/PetTalkReplyController.java
@@ -1,40 +1,41 @@
-//package com.itoxi.petnuri.domain.petTalk.controller;
-//
-//import com.itoxi.petnuri.domain.member.entity.Member;
-//import com.itoxi.petnuri.domain.petTalk.dto.request.WritePetTalkReplyReq;
-//import com.itoxi.petnuri.domain.petTalk.dto.response.GetAllPetTalkReplyResp;
-//import com.itoxi.petnuri.domain.petTalk.service.PetTalkReplyService;
-//import com.itoxi.petnuri.global.common.customValid.valid.ValidId;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.security.core.annotation.AuthenticationPrincipal;
-//import org.springframework.validation.annotation.Validated;
-//import org.springframework.web.bind.annotation.*;
-//
-//@RestController
-//@RequestMapping("/pet-talk")
-//@RequiredArgsConstructor
-//@Validated
-//public class PetTalkReplyController {
-//    private final PetTalkReplyService petTalkReplyService;
-//
-//    @PostMapping("/{petTalkId}/reply")
-//    public ResponseEntity<Object> write(
-//            @PathVariable @ValidId Long petTalkId,
-//            @RequestBody WritePetTalkReplyReq request,
-//            @AuthenticationPrincipal PrincipalDetails principalDetails
-//    ) {
-//        Member member = principalDetails.getMember();
-//        petTalkReplyService.write(member, petTalkId, request);
-//        return new ResponseEntity<>(null, HttpStatus.CREATED);
-//    }
-//
-//    @GetMapping("/{petTalkId}/replys")
-//    public ResponseEntity<GetAllPetTalkReplyResp> getAll(
-//            @PathVariable @ValidId Long petTalkId
-//    ) {
-//        GetAllPetTalkReplyResp response = petTalkReplyService.getAll(petTalkId);
-//        return new ResponseEntity<>(response, HttpStatus.OK);
-//    }
-//}
+package com.itoxi.petnuri.domain.petTalk.controller;
+
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.domain.petTalk.dto.request.WritePetTalkReplyReq;
+import com.itoxi.petnuri.domain.petTalk.dto.response.GetAllPetTalkReplyResp;
+import com.itoxi.petnuri.domain.petTalk.service.PetTalkReplyService;
+import com.itoxi.petnuri.global.common.customValid.valid.ValidId;
+import com.itoxi.petnuri.global.security.auth.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/pet-talk")
+@RequiredArgsConstructor
+@Validated
+public class PetTalkReplyController {
+    private final PetTalkReplyService petTalkReplyService;
+
+    @PostMapping("/{petTalkId}/reply")
+    public ResponseEntity<Object> write(
+            @PathVariable @ValidId Long petTalkId,
+            @RequestBody WritePetTalkReplyReq request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        Member member = principalDetails.getMember();
+        petTalkReplyService.write(member, petTalkId, request);
+        return new ResponseEntity<>(null, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{petTalkId}/replys")
+    public ResponseEntity<GetAllPetTalkReplyResp> getAll(
+            @PathVariable @ValidId Long petTalkId
+    ) {
+        GetAllPetTalkReplyResp response = petTalkReplyService.getAll(petTalkId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/dto/response/GetAllPetTalkReplyResp.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/dto/response/GetAllPetTalkReplyResp.java
@@ -37,7 +37,7 @@ public class GetAllPetTalkReplyResp {
 
         public WriterDTO(Member member) {
             this.writerId = member.getId();
-            this.profileImageUrl = member.getImage();
+            this.profileImageUrl = member.getProfileImageUrl();
             this.nickname = member.getNickname();
         }
     }


### PR DESCRIPTION
## 요약
멤버의 프로필 이미지 필드명이 image -> profileImageUrl로 수정되면서
프로필 이미지를 참조하는 다른 코드에서 오류 발생

## 작업 내용
- [x] getter 명 변경
- [x] controller 주석처리 해제

## 참고 사항

## 관련 이슈
Close #36
