### PR TITLE
[#69] 챌린지 메인 화면의 데일리 챌린지 리스트 출력 api 구현

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyChallengeController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyChallengeController.java
@@ -1,0 +1,37 @@
+package com.itoxi.petnuri.domain.dailychallenge.controller;
+
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
+import com.itoxi.petnuri.domain.dailychallenge.service.DailyChallengeService;
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.global.security.auth.PrincipalDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-25
+ * description    :
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/challenge/daily")
+public class DailyChallengeController {
+
+    private final DailyChallengeService dailyChallengeService;
+
+    @GetMapping
+    public ResponseEntity challengeMainView(
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Member member = principalDetails.getMember();
+
+        List<DailyChallengeListResponse> responses = dailyChallengeService.respDailyChallengeList(member);
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/DailyAuthDto.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/DailyAuthDto.java
@@ -12,6 +12,6 @@ import lombok.Getter;
 @Builder
 public class DailyAuthDto {
     private Long payment;
-    private String challengeName;
+    private String challengeTitle;
     private String authImageUrl;
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyAuthImageResponse.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyAuthImageResponse.java
@@ -1,0 +1,13 @@
+package com.itoxi.petnuri.domain.dailychallenge.dto.response;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-26
+ * description    :
+ */
+public class DailyAuthImageResponse {
+
+    private Long memberId;  // 인증글을 작성한 회원 id
+    private String nickName; // 안증글울 작성한 회원의 닉네임
+    private String imageUrl; // 인증 사진 url
+}

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyChallengeDetailResponse.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyChallengeDetailResponse.java
@@ -1,0 +1,16 @@
+package com.itoxi.petnuri.domain.dailychallenge.dto.response;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-26
+ * description    :
+ */
+public class DailyChallengeDetailResponse {
+
+    private Long id;         // 챌린지 id
+    private String banner;   // 챌린지 배너 이미지 url
+    private String title;    // 챌린지명
+    private String subTitle; // 챌린지 소제목
+    private Boolean status;  // 로그인 한 유저의 인증글 작성 여부
+
+}

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyChallengeListResponse.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyChallengeListResponse.java
@@ -1,0 +1,21 @@
+package com.itoxi.petnuri.domain.dailychallenge.dto.response;
+
+import lombok.*;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-25
+ * description    :
+ */
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DailyChallengeListResponse {
+
+    private Long challengeId; // 챌린지 id
+    private String title;     // 챌린지명
+    private String thumbnail; // 챌린지 썸네일
+    private Boolean status;   // 유저의 인증글 작성 여부
+
+}

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/entity/DailyAuth.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/entity/DailyAuth.java
@@ -50,4 +50,11 @@ public class DailyAuth extends BaseTimeEntity {
     @Column(nullable = false)
     private String imageUrl;  // 인증샷 S3 url
 
+    public static DailyAuth createDailyAuth(Member member, DailyChallenge dailyChallenge, String imageUrl) {
+        return DailyAuth.builder()
+                .member(member)
+                .dailyChallenge(dailyChallenge)
+                .imageUrl(imageUrl)
+                .build();
+    }
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/entity/DailyChallenge.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/entity/DailyChallenge.java
@@ -30,7 +30,11 @@ public class DailyChallenge extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String name;       // 챌린지명
+    private String title;       // 챌린지명
+
+    @Column(nullable = false)
+    private String subTitle;    // 챌린지 소제목
+
 
     @Column(name = "auth_method", nullable = false)
     private String authMethod; // 챌린지 인증 방법

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepository.java
@@ -1,7 +1,6 @@
 package com.itoxi.petnuri.domain.dailychallenge.repository;
 
 import com.itoxi.petnuri.domain.dailychallenge.entity.DailyAuth;
-import com.itoxi.petnuri.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -9,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * date           : 2023-09-16
  * description    :
  */
-public interface DailyAuthRepository extends JpaRepository<DailyAuth, Long> {
-
-    boolean existsDailyAuthByMember(Member member);
+public interface DailyAuthRepository extends JpaRepository<DailyAuth, Long>, DailyAuthRepositoryCustom {
+    
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryCustom.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.itoxi.petnuri.domain.dailychallenge.repository;
+
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
+import com.itoxi.petnuri.domain.member.entity.Member;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-26
+ * description    :
+ */
+public interface DailyAuthRepositoryCustom {
+
+    boolean dupePostCheck(Member member, DailyChallenge dailyChallenge);
+}

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImpl.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.itoxi.petnuri.domain.dailychallenge.repository;
+
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
+import com.itoxi.petnuri.domain.dailychallenge.entity.QDailyAuth;
+import com.itoxi.petnuri.domain.dailychallenge.util.QuerydslDateTimeFormatter;
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-26
+ * description    :
+ */
+@RequiredArgsConstructor
+public class DailyAuthRepositoryImpl implements DailyAuthRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QuerydslDateTimeFormatter querydslFormatter;
+
+    QDailyAuth dailyAuth = QDailyAuth.dailyAuth;
+
+    @Override
+    public boolean dupePostCheck(Member loginMember, DailyChallenge dailyChallenge) {
+        StringExpression authDate = querydslFormatter.formatter(dailyAuth.updatedAt);
+        String todayStr = querydslFormatter.nowDateTimeToStr();
+
+        Member result = queryFactory
+                .select(dailyAuth.member)
+                .from(dailyAuth)
+                .where(dailyAuth.id.eq(dailyChallenge.getId())
+                        .and(dailyAuth.member.id.eq(loginMember.getId()))
+                        .and(authDate.eq(todayStr)))
+                .fetchOne();
+        return (result != null) ? true : false; // true : 중복 인증
+    }
+
+}

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * date           : 2023-09-16
  * description    :
  */
-public interface DailyChallengeRepository extends JpaRepository<DailyChallenge, Long> {
+public interface DailyChallengeRepository extends JpaRepository<DailyChallenge, Long>, DailyChallengeRepositoryCustom {
 
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryCustom.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.itoxi.petnuri.domain.dailychallenge.repository;
+
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
+import com.itoxi.petnuri.domain.member.entity.Member;
+
+import java.util.List;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-25
+ * description    :
+ */
+public interface DailyChallengeRepositoryCustom {
+
+    List<DailyChallengeListResponse> listChallenge(Member loginMember);
+
+}

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.itoxi.petnuri.domain.dailychallenge.repository;
+
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
+import com.itoxi.petnuri.domain.dailychallenge.entity.QDailyAuth;
+import com.itoxi.petnuri.domain.dailychallenge.entity.QDailyChallenge;
+import com.itoxi.petnuri.domain.dailychallenge.type.ChallengeStatus;
+import com.itoxi.petnuri.domain.dailychallenge.util.QuerydslDateTimeFormatter;
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.*;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-25
+ * description    :
+ */
+@RequiredArgsConstructor
+public class DailyChallengeRepositoryImpl implements DailyChallengeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QuerydslDateTimeFormatter querydslFormatter;
+    QDailyChallenge dailyChallenge = QDailyChallenge.dailyChallenge;
+    QDailyAuth dailyAuth = QDailyAuth.dailyAuth;
+
+    // 챌린지 메인 화면 데일리 챌린지 화면 파트 응답용
+    @Override
+    public List<DailyChallengeListResponse> listChallenge(Member loginMember) {
+
+        StringExpression authDate = querydslFormatter.formatter(dailyAuth.updatedAt);
+        String todayStr = querydslFormatter.nowDateTimeToStr();
+
+        return queryFactory
+                .select(Projections.constructor(DailyChallengeListResponse.class,
+                        dailyChallenge.id, dailyChallenge.title,
+                        dailyChallenge.thumbnail,
+                        dailyAuth.member.isNotNull()))
+                .from(dailyChallenge)
+                .leftJoin(dailyAuth)
+                .on(dailyChallenge.id.eq(dailyAuth.dailyChallenge.id)
+                        .and(dailyAuth.member.id.eq(loginMember.getId()))
+                        .and(authDate.eq(todayStr)))
+                .where(dailyChallenge.challengeStatus.eq(ChallengeStatus.OPENED))
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyChallengeService.java
@@ -1,0 +1,47 @@
+package com.itoxi.petnuri.domain.dailychallenge.service;
+
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyAuthImageResponse;
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
+import com.itoxi.petnuri.domain.dailychallenge.repository.DailyAuthRepository;
+import com.itoxi.petnuri.domain.dailychallenge.repository.DailyChallengeRepository;
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-25
+ * description    :
+ */
+@Service
+@RequiredArgsConstructor
+public class DailyChallengeService {
+
+    private final DailyChallengeRepository dailyChallengeRepository;
+    private final DailyAuthRepository dailyAuthRepository;
+    private final MemberRepository memberRepository;
+
+    public List<DailyChallengeListResponse> respDailyChallengeList(Member loginMember) {
+        // 반환에 필요한 데이터 : 챌린지 id, 챌리지명, 로그인한 유저의 참여 여부, 썸네일 url
+        Member member = memberRepository.findById(loginMember.getId())
+                .orElseThrow(NoSuchElementException::new);
+        System.out.printf("테스트 : loginMember = %d, %s%n", member.getId(), member.getNickname());
+
+        List<DailyChallengeListResponse> allWithMember = dailyChallengeRepository.listChallenge(loginMember);
+        for (DailyChallengeListResponse response : allWithMember) {
+            System.out.println(response);
+        }
+        return allWithMember;
+    }
+
+    public Page<List<DailyAuthImageResponse>> respDailyChallengeAuthList(Long dailyChallengeId) {
+
+        return null;
+    }
+}
+

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/util/QuerydslDateTimeFormatter.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/util/QuerydslDateTimeFormatter.java
@@ -1,0 +1,41 @@
+package com.itoxi.petnuri.domain.dailychallenge.util;
+
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-26
+ * description    :
+ */
+@Component
+@RequiredArgsConstructor
+public class QuerydslDateTimeFormatter {
+    // Todo: 서버 배포시 .yml에서 profiles 값을 읽어 오도록 코드 변경
+    @Value("${spring.datasource.driver-class-name}")
+    private String dbName;
+
+    public StringExpression formatter(DateTimePath<LocalDateTime> reqDateTime) {
+        StringExpression transferDate = null;
+        if (dbName.contains("mysql")) {
+            // MySQL Expression
+            transferDate = Expressions.stringTemplate("FUNCTION('DATE_FORMAT', {0}, '%Y-%m-%d')", reqDateTime);
+        } else {
+            // H2 Expression
+            transferDate = Expressions.stringTemplate("FUNCTION('FORMATDATETIME', {0}, 'yyyy-MM-dd')", reqDateTime);
+        }
+        return transferDate;
+    }
+
+    public String nowDateTimeToStr() {
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return LocalDateTime.now().format(format);
+    }
+}

--- a/src/main/java/com/itoxi/petnuri/domain/member/dto/response/MainResp.java
+++ b/src/main/java/com/itoxi/petnuri/domain/member/dto/response/MainResp.java
@@ -85,7 +85,7 @@ public class MainResp {
 
         public DailyChallengeDTO(DailyChallenge dailyChallenge) {
             this.id = dailyChallenge.getId();
-            this.title = dailyChallenge.getName();
+            this.title = dailyChallenge.getTitle();
 //            this.subTitle = dailyChallenge;
             this.thumbnail = dailyChallenge.getThumbnail();
         }

--- a/src/main/java/com/itoxi/petnuri/domain/point/PointGetDto.java
+++ b/src/main/java/com/itoxi/petnuri/domain/point/PointGetDto.java
@@ -1,7 +1,6 @@
 package com.itoxi.petnuri.domain.point;
 
 import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
-import com.itoxi.petnuri.domain.point.entity.Point;
 import lombok.*;
 
 /**
@@ -18,7 +17,7 @@ public class PointGetDto {
 
     public static PointGetDto from(DailyChallenge dailyChallenge) {
         return PointGetDto.builder()
-                .challengeName(dailyChallenge.getName())
+                .challengeName(dailyChallenge.getTitle())
                 .point(dailyChallenge.getPayment())
                 .build();
     }

--- a/src/main/java/com/itoxi/petnuri/domain/point/service/PointService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/point/service/PointService.java
@@ -40,7 +40,7 @@ public class PointService {
                 .orElseGet(() -> createPoint(member)); // 회원의 포인트 정보가 null이면 신규 생성.
 
         PointHistory pointHistory = PointHistory.createGetPointHistory(
-                point, dailyAuthDto.getPayment(), dailyAuthDto.getChallengeName());
+                point, dailyAuthDto.getPayment(), dailyAuthDto.getChallengeTitle());
         pointHistoryRepository.save(pointHistory);
 
         return point.getHavePoint();

--- a/src/main/java/com/itoxi/petnuri/global/s3/service/AmazonS3Service.java
+++ b/src/main/java/com/itoxi/petnuri/global/s3/service/AmazonS3Service.java
@@ -109,6 +109,11 @@ public class AmazonS3Service {
         return uploadImage(PET_IMAGE_PREFIX, image);
     }
 
+    // 데일리 챌린지 인증 사진 저장
+    public String uploadDailyChallengeAuthImage(MultipartFile file) {
+        return uploadImage(DAILY_CHALLENGE_IMAGE_PREFIX, file);
+    }
+
     // 단일 파일 저장
     private String uploadImage(String subject, MultipartFile file) {
         String fileKey = subject + createDatePath() + generateRandomFileName();
@@ -142,11 +147,8 @@ public class AmazonS3Service {
         return amazonS3.getUrl(bucket, fileKey).toString();
     }
 
-    private final Function<String, String> getPrefix =
-            prefix -> DAILY_CHALLENGE_IMAGE_PREFIX + createDatePath() + generateRandomFileName();
-
     // S3 deleteObject()의 filename 생성용
-    private final Function<String, String> getFileNameFromUrl = url -> {
+    private String getFileNameFromUrl(String url) {
         // 1. amazonaws.com 이 위치한 문자열 index를 가져온다.
         int startIndex = url.indexOf(".com");
 
@@ -155,16 +157,5 @@ public class AmazonS3Service {
 
         // 3. fromIndex부터 끝까지 문자열을 잘라서 filename을 만들어서 반환.
         return url.substring(fromIndex, url.length());
-    };
-
-    public String uploadDailyChallengeImage(MultipartFile file) {
-        String fileKey = getPrefix.apply(DAILY_CHALLENGE_IMAGE_PREFIX);
-        ObjectMetadata metadata = createObjectMetadataFromFile(file);
-        try {
-            amazonS3.putObject(bucket, fileKey, file.getInputStream(), metadata);
-        } catch (Exception e) {
-            throw new Exception500(ErrorCode.FILE_TRANSFER_ERROR);
-        }
-        return getUrlFromBucket(fileKey);
     }
 }

--- a/src/main/resources/table/h2/data.sql
+++ b/src/main/resources/table/h2/data.sql
@@ -18,11 +18,23 @@ VALUES ('질병/질환', 1),
 -- INSERT INTO pet_talk (title, content, main_category_id, sub_category_id, pet_type, status, view_count, member_id)
 -- VALUES ('제목1', '내용1', 1, 1, 'DOG', 'ACTIVE', 0, 1);
 
--- 데일리 챌린지 데이터 생성
-insert into daily_challenge (name, auth_method, payment, payment_method, thumbnail, banner, start_date, end_date,
-                             challenge_status, created_at, updated_at)
-values ('데일리 간식주기', '반려동물에게 간식주는 사진을 인증해요!', 100, '참여 완료 즉시 지급', 'https://test.url/thumbnail.jpg',
-        'https://test.url/banner.jpg', '2023-09-16 00:00:00', '9999-12-31 23:59:59', 'OPENED', now(), now());
+-- 데일리 챌린지 더미 데이터 생성
+insert into daily_challenge (title, sub_title, auth_method, payment, payment_method, thumbnail, banner,
+                             start_date, end_date, challenge_status, created_at, updated_at)
+values ('간식주기 챌린지', '반려동물에게 간식주는 사진을 인증해요!', '인증 사진 업로드!', 100, '참여완료 즉시 지급',
+        'https://www.test.url/thumbnail.jpg', 'https://test.url/banner.jpg',
+        '2023-09-16 00:00:00', '9999-12-31 23:59:59', 'OPENED', now(), now());
+insert into daily_challenge (title, sub_title, auth_method, payment, payment_method, thumbnail, banner,
+                             start_date, end_date, challenge_status, created_at, updated_at)
+values ('놀아주기 챌린지', '반려동물과 즐거운 시간을 보내는 사진을 인증해요!', '인증 사진 업로드!', 100, '참여완료 즉시 지급',
+        'https://www.test.url/thumbnail.jpg', 'https://test.url/banner.jpg',
+        '2023-09-16 00:00:00', '9999-12-31 23:59:59', 'OPENED', now(), now());
+insert into daily_challenge (title, sub_title, auth_method, payment, payment_method, thumbnail, banner,
+                             start_date, end_date, challenge_status, created_at, updated_at)
+values ('위생관리 챌린지', '반려동물의 위생/청결관리 사진을 인증해요!', '인증 사진 업로드!', 100, '참여완료 즉시 지급',
+        'https://www.test.url/thumbnail.jpg', 'https://test.url/banner.jpg',
+        '2023-09-16 00:00:00', '9999-12-31 23:59:59', 'OPENED', now(), now());
+
 
 insert into reward_challenge (title, sub_title, notice, thumbnail, poster, status, start_date, end_date,
                               kit_start_date, kit_end_date, review_start_date, review_end_date, created_at, updated_at)

--- a/src/main/resources/table/h2/schema.sql
+++ b/src/main/resources/table/h2/schema.sql
@@ -11,12 +11,12 @@ DROP TABLE IF EXISTS challenge_delivery;
 
 CREATE TABLE member
 (
-    member_id     SERIAL PRIMARY KEY,
-    email         VARCHAR(255) UNIQUE NOT NULL,
-    nickname      VARCHAR(255) UNIQUE NOT NULL,
+    member_id         SERIAL PRIMARY KEY,
+    email             VARCHAR(255) UNIQUE NOT NULL,
+    nickname          VARCHAR(255) UNIQUE NOT NULL,
     profile_image_url VARCHAR(255),
-    role          VARCHAR(20)         NOT NULL,
-    referral_code VARCHAR(255)
+    role              VARCHAR(20)         NOT NULL,
+    referral_code     VARCHAR(255)
 );
 
 CREATE TABLE main_category
@@ -36,7 +36,8 @@ CREATE TABLE sub_category
 create table daily_challenge
 (
     daily_challenge_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name               varchar(255) not null,
+    title              varchar(255) not null,
+    sub_title          varchar(255) not null,
     auth_method        varchar(255) not null,
     payment            bigint       not null,
     payment_method     varchar(255) not null,
@@ -54,7 +55,7 @@ create table reward_challenge
     reward_challenge_id BIGINT AUTO_INCREMENT PRIMARY KEY,
     title               VARCHAR(255) NOT NULL,
     sub_title           VARCHAR(255) NOT NULL,
-    notice              VARCHAR(255) ,
+    notice              VARCHAR(255),
     thumbnail           VARCHAR(255) NOT NULL,
     poster              VARCHAR(255) NOT NULL,
     status              VARCHAR(255) NOT NULL,
@@ -83,20 +84,20 @@ create table reward_challenger
 
 CREATE TABLE product
 (
-    product_id  BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name        VARCHAR(255) NOT NULL,
-    category    VARCHAR(255) NOT NULL,
-    brand       VARCHAR(255) NOT NULL,
-    price       BIGINT       NOT NULL,
-    quantity    BIGINT       NOT NULL,
-    image       VARCHAR(255)
+    product_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name       VARCHAR(255) NOT NULL,
+    category   VARCHAR(255) NOT NULL,
+    brand      VARCHAR(255) NOT NULL,
+    price      BIGINT       NOT NULL,
+    quantity   BIGINT       NOT NULL,
+    image      VARCHAR(255)
 );
 
 CREATE TABLE challenge_product
 (
     challenge_product_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    product_id           BIGINT NOT NULL,
-    reward_challenge_id  BIGINT NOT NULL,
+    product_id           BIGINT       NOT NULL,
+    reward_challenge_id  BIGINT       NOT NULL,
     category             VARCHAR(255) NOT NULL,
     FOREIGN KEY (product_id) REFERENCES product (product_id),
     FOREIGN KEY (reward_challenge_id) REFERENCES reward_challenge (reward_challenge_id)


### PR DESCRIPTION
## 요약
챌린지 메인 화면의 데일리 챌린지 리스트 출력 api 구현

## 작업 내용
- 데일리 챌린지 엔티티에 소제목 필드 추가 및 그에 따른 로직 수정
- DB 테이블 수정 및 더미 데이터 수정
- 데일리 챌린지 중복 인증 방지 로직 수정
- 챌린지 메인 화면의 데일리 챌린지 리스트 출력 api 구현

## 참고 사항

## 관련 이슈
Close #69 
