### PR TITLE
[#115] 데일리 챌린지 인증 사진 목록 응답 api 구현

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyAuthController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyAuthController.java
@@ -39,7 +39,7 @@ public class DailyAuthController {
             @PathVariable @ValidId Long challengeId,
             @RequestPart MultipartFile file) {
         
-        isNotEmptyFile.accept(file); // 업로드한 파일의 유효성 검사
+        isNotEmptyFile(file); // 업로드한 파일의 유효성 검사
         Member member = principalDetails.getMember();
 
         // 1. 인증 글 등록 후 포인트 적립을 위한 데이터 받아 오기
@@ -52,9 +52,9 @@ public class DailyAuthController {
         return new ResponseEntity<>(dailyAuthResponse, HttpStatus.CREATED); // 201 OK
     }
 
-    private final Consumer<MultipartFile> isNotEmptyFile = file -> {
-        if (file.isEmpty()) {
+    private void isNotEmptyFile(MultipartFile file) {
+        if (file.isEmpty() || file == null) {
             throw new Exception400(INVALID_FILE_REQUEST);
         }
-    };
+    }
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyAuthController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyAuthController.java
@@ -19,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.function.Consumer;
 
 import static com.itoxi.petnuri.global.common.exception.type.ErrorCode.INVALID_FILE_REQUEST;
+import static com.itoxi.petnuri.global.common.exception.type.ErrorCode.REQUIRED_LOGIN_ERROR;
 
 /**
  * author         : matrix
@@ -40,21 +41,28 @@ public class DailyAuthController {
             @RequestPart MultipartFile file) {
         
         isNotEmptyFile(file); // 업로드한 파일의 유효성 검사
-        Member member = principalDetails.getMember();
+        Member loginMember = isLoginMember(principalDetails); // NPE 방지
 
         // 1. 인증 글 등록 후 포인트 적립을 위한 데이터 받아 오기
-        DailyAuthDto dailyAuthDto = dailyAuthService.saveAuth(member, challengeId, file);
+        DailyAuthDto dailyAuthDto = dailyAuthService.saveAuth(loginMember, challengeId, file);
 
         // 2. 포인트 적립 후 현재 회원의 보유 포인트 받아 오기
-        Long point = pointService.getPoint(dailyAuthDto, member.getId());
+        Long point = pointService.getPoint(dailyAuthDto, loginMember.getId());
 
-        DailyAuthResponse dailyAuthResponse = DailyAuthResponse.of(dailyAuthDto, member, point);
-        return new ResponseEntity<>(dailyAuthResponse, HttpStatus.CREATED); // 201 OK
+        DailyAuthResponse response = DailyAuthResponse.of(dailyAuthDto, loginMember, point);
+        return new ResponseEntity<>(response, HttpStatus.CREATED); // 201 OK
     }
 
     private void isNotEmptyFile(MultipartFile file) {
         if (file.isEmpty() || file == null) {
             throw new Exception400(INVALID_FILE_REQUEST);
         }
+    }
+
+    private Member isLoginMember(PrincipalDetails principalDetails) {
+        if (principalDetails == null) { // NullPointerException 방지
+            throw new Exception400(REQUIRED_LOGIN_ERROR);
+        }
+        return principalDetails.getMember();
     }
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyChallengeController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyChallengeController.java
@@ -1,14 +1,20 @@
 package com.itoxi.petnuri.domain.dailychallenge.controller;
 
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyAuthImageResponse;
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeDetailResponse;
 import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
 import com.itoxi.petnuri.domain.dailychallenge.service.DailyChallengeService;
 import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.global.common.customValid.valid.ValidId;
 import com.itoxi.petnuri.global.security.auth.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,11 +33,42 @@ public class DailyChallengeController {
     private final DailyChallengeService dailyChallengeService;
 
     @GetMapping
-    public ResponseEntity challengeMainView(
+    public ResponseEntity getChallengeMainView(
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        Member member = principalDetails.getMember();
+        Member loginMember = isLoginMember(principalDetails);
 
-        List<DailyChallengeListResponse> responses = dailyChallengeService.respDailyChallengeList(member);
+        List<DailyChallengeListResponse> responses = dailyChallengeService.respDailyChallengeList(loginMember);
         return ResponseEntity.ok(responses);
     }
+
+    @GetMapping("/{challengeId}")
+    public ResponseEntity getChallengeDetailView(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable @ValidId Long challengeId
+    ) {
+        Member loginMember = isLoginMember(principalDetails);
+
+        DailyChallengeDetailResponse responses =
+                dailyChallengeService.respDailyChallengeDetail(challengeId, loginMember);
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/{challengeId}/auth")
+    public ResponseEntity<?> getAllAuthList(
+            @PathVariable @ValidId Long challengeId,
+            @PageableDefault(size = 5) Pageable pageable
+    ) {
+        Page<DailyAuthImageResponse> responses =
+                dailyChallengeService.respDailyChallengeAuthList(challengeId, pageable);
+        return ResponseEntity.ok(responses);
+    }
+
+
+    private Member isLoginMember(PrincipalDetails principalDetails) {
+        if (principalDetails == null) { // NullPointerException 방지
+            return null;
+        }
+        return principalDetails.getMember();
+    }
+
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/DailyAuthDto.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/DailyAuthDto.java
@@ -1,5 +1,7 @@
 package com.itoxi.petnuri.domain.dailychallenge.dto;
 
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyAuth;
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,4 +17,14 @@ public class DailyAuthDto {
     private Long payment;
     private String challengeTitle;
     private String authImageUrl;
+
+    public static DailyAuthDto of(DailyAuth dailyAuth, DailyChallenge dailyChallenge) {
+        return DailyAuthDto.builder()
+                .challengeId(dailyChallenge.getId())
+                .payment(dailyChallenge.getPayment())
+                .challengeTitle(dailyChallenge.getTitle())
+                .authImageUrl(dailyAuth.getImageUrl())
+                .build();
+    }
+    
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/DailyAuthDto.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/DailyAuthDto.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class DailyAuthDto {
+    private Long challengeId;
     private Long payment;
     private String challengeTitle;
     private String authImageUrl;

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyAuthImageResponse.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyAuthImageResponse.java
@@ -1,13 +1,20 @@
 package com.itoxi.petnuri.domain.dailychallenge.dto.response;
 
+import lombok.*;
+
 /**
  * author         : Jisang Lee
  * date           : 2023-09-26
  * description    :
  */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class DailyAuthImageResponse {
 
-    private Long memberId;  // 인증글을 작성한 회원 id
-    private String nickName; // 안증글울 작성한 회원의 닉네임
-    private String imageUrl; // 인증 사진 url
+    private Long challengeId; // 데일리 챌린지 id
+    private Long memberId;    // 인증글을 작성한 회원 id
+    private String nickName;  // 안증글울 작성한 회원의 닉네임
+    private String imageUrl;  // 인증 사진 url
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyAuthResponse.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyAuthResponse.java
@@ -14,13 +14,15 @@ import lombok.Getter;
 @Builder
 public class DailyAuthResponse {
 
-    private Long memberId;      // 인증을 완료한 회원의 id
-    private String nickname;    // 인증을 완료한 회원의 닉네임
-    private String reviewImg;   // 해당 회원의 인증사진
-    private Long memberPoint;   // 해당 회원의 인증 후 보유 포인트
+    private Long challengeId;  // 데일리 챌린지 id
+    private Long memberId;     // 인증을 완료한 회원의 id
+    private String nickname;   // 인증을 완료한 회원의 닉네임
+    private String reviewImg;  // 해당 회원의 인증사진
+    private Long memberPoint;  // 해당 회원의 인증 후 보유 포인트
 
     public static DailyAuthResponse of(DailyAuthDto dailyAutoDto, Member member, Long point) {
         return DailyAuthResponse.builder()
+                .challengeId(dailyAutoDto.getChallengeId())
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .reviewImg(dailyAutoDto.getAuthImageUrl())

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyChallengeDetailResponse.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/dto/response/DailyChallengeDetailResponse.java
@@ -1,16 +1,25 @@
 package com.itoxi.petnuri.domain.dailychallenge.dto.response;
 
+import lombok.*;
+
 /**
  * author         : Jisang Lee
  * date           : 2023-09-26
  * description    :
  */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class DailyChallengeDetailResponse {
 
-    private Long id;         // 챌린지 id
-    private String banner;   // 챌린지 배너 이미지 url
-    private String title;    // 챌린지명
-    private String subTitle; // 챌린지 소제목
-    private Boolean status;  // 로그인 한 유저의 인증글 작성 여부
+    private Long challengeId;    // 챌린지 id
+    private String banner;       // 챌린지 배너 이미지 url
+    private String title;        // 챌린지명
+    private String subTitle;     // 챌린지 소제목
+    private String authMethod;   // 챌린지 인증방법
+    private Long point;         // 챌린지 리워드 포인트
+    private String pointMethod; // 포인트 지급 방법
+    private Boolean status;      // 로그인 한 유저의 인증글 작성 여부
 
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/entity/DailyAuth.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/entity/DailyAuth.java
@@ -50,7 +50,9 @@ public class DailyAuth extends BaseTimeEntity {
     @Column(nullable = false)
     private String imageUrl;  // 인증샷 S3 url
 
-    public static DailyAuth createDailyAuth(Member member, DailyChallenge dailyChallenge, String imageUrl) {
+    public static DailyAuth createDailyAuth(
+            Member member, DailyChallenge dailyChallenge, String imageUrl
+    ) {
         return DailyAuth.builder()
                 .member(member)
                 .dailyChallenge(dailyChallenge)

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/entity/DailyChallenge.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/entity/DailyChallenge.java
@@ -43,7 +43,7 @@ public class DailyChallenge extends BaseTimeEntity {
     private Long payment;      // 챌린지 인증 완료시 지급 포인트
 
     @Column(name = "payment_method", nullable = false)
-    private String paymentMethod; // 챌린지 인증 완료시 지급 포인트
+    private String paymentMethod; // 포인트 지급 방법
 
     @Column(nullable = false)
     private String thumbnail;   // S3 url
@@ -62,7 +62,5 @@ public class DailyChallenge extends BaseTimeEntity {
     @Column(nullable = false)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime endDate;      // 챌린지 종료 일자 : 9999-12-31 23:59:59
-
-
 
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImpl.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImpl.java
@@ -4,9 +4,13 @@ import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
 import com.itoxi.petnuri.domain.dailychallenge.entity.QDailyAuth;
 import com.itoxi.petnuri.domain.dailychallenge.util.QuerydslDateTimeFormatter;
 import com.itoxi.petnuri.domain.member.entity.Member;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
 
 /**
  * author         : Jisang Lee
@@ -23,17 +27,21 @@ public class DailyAuthRepositoryImpl implements DailyAuthRepositoryCustom {
 
     @Override
     public boolean dupePostCheck(Member loginMember, DailyChallenge dailyChallenge) {
-        StringExpression authDate = querydslFormatter.formatter(dailyAuth.updatedAt);
-        String todayStr = querydslFormatter.nowDateTimeToStr();
 
         Member result = queryFactory
                 .select(dailyAuth.member)
                 .from(dailyAuth)
                 .where(dailyAuth.id.eq(dailyChallenge.getId())
                         .and(dailyAuth.member.id.eq(loginMember.getId()))
-                        .and(authDate.eq(todayStr)))
+                        .and(todayEq(dailyAuth.updatedAt)))
                 .fetchOne();
         return (result != null) ? true : false; // true : 중복 인증
+    }
+
+    private BooleanExpression todayEq(DateTimePath<LocalDateTime> dailyAuth) {
+        String todayStr = querydslFormatter.nowDateTimeToStr();
+        StringExpression authDate = querydslFormatter.formatter(dailyAuth);
+        return authDate.eq(todayStr);
     }
 
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryCustom.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryCustom.java
@@ -1,7 +1,12 @@
 package com.itoxi.petnuri.domain.dailychallenge.repository;
 
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyAuthImageResponse;
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeDetailResponse;
 import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
 import com.itoxi.petnuri.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -12,6 +17,12 @@ import java.util.List;
  */
 public interface DailyChallengeRepositoryCustom {
 
-    List<DailyChallengeListResponse> listChallenge(Member loginMember);
+    List<DailyChallengeListResponse> findAllWithAuthStatus(Member loginMember);
+
+    Page<DailyAuthImageResponse> findAllAuthList(
+            DailyChallenge dailyChallenge, Pageable pageable);
+
+    DailyChallengeDetailResponse findDetailChallenge(
+            DailyChallenge dailyChallenge, Member loginMember);
 
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
@@ -1,16 +1,25 @@
 package com.itoxi.petnuri.domain.dailychallenge.repository;
 
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyAuthImageResponse;
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeDetailResponse;
 import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
 import com.itoxi.petnuri.domain.dailychallenge.entity.QDailyAuth;
 import com.itoxi.petnuri.domain.dailychallenge.entity.QDailyChallenge;
 import com.itoxi.petnuri.domain.dailychallenge.type.ChallengeStatus;
 import com.itoxi.petnuri.domain.dailychallenge.util.QuerydslDateTimeFormatter;
 import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.domain.member.entity.QMember;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.*;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -21,30 +30,85 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DailyChallengeRepositoryImpl implements DailyChallengeRepositoryCustom {
 
-    private final JPAQueryFactory queryFactory;
-    private final QuerydslDateTimeFormatter querydslFormatter;
     QDailyChallenge dailyChallenge = QDailyChallenge.dailyChallenge;
     QDailyAuth dailyAuth = QDailyAuth.dailyAuth;
+    QMember member = QMember.member;
+
+    private final JPAQueryFactory queryFactory;
+    private final QuerydslDateTimeFormatter querydslFormatter;
 
     // 챌린지 메인 화면 데일리 챌린지 화면 파트 응답용
     @Override
-    public List<DailyChallengeListResponse> listChallenge(Member loginMember) {
-
-        StringExpression authDate = querydslFormatter.formatter(dailyAuth.updatedAt);
-        String todayStr = querydslFormatter.nowDateTimeToStr();
+    public List<DailyChallengeListResponse> findAllWithAuthStatus(Member loginMember) {
 
         return queryFactory
                 .select(Projections.constructor(DailyChallengeListResponse.class,
                         dailyChallenge.id, dailyChallenge.title,
-                        dailyChallenge.thumbnail,
-                        dailyAuth.member.isNotNull()))
+                        dailyChallenge.thumbnail, dailyAuth.member.isNotNull()))
                 .from(dailyChallenge)
                 .leftJoin(dailyAuth)
                 .on(dailyChallenge.id.eq(dailyAuth.dailyChallenge.id)
-                        .and(dailyAuth.member.id.eq(loginMember.getId()))
-                        .and(authDate.eq(todayStr)))
+                        .and(memberEq(dailyAuth.member, loginMember))
+                        .and(todayEq(dailyAuth.updatedAt)))
                 .where(dailyChallenge.challengeStatus.eq(ChallengeStatus.OPENED))
                 .fetch();
     }
 
+    @Override
+    public DailyChallengeDetailResponse findDetailChallenge(
+            DailyChallenge challenge, Member loginMember
+    ) {
+        return queryFactory
+                .select(Projections.constructor(DailyChallengeDetailResponse.class,
+                        dailyChallenge.id, dailyChallenge.banner, dailyChallenge.title,
+                        dailyChallenge.subTitle, dailyChallenge.authMethod, dailyChallenge.payment,
+                        dailyChallenge.paymentMethod, dailyAuth.member.isNotNull()))
+                .from(dailyChallenge)
+                .leftJoin(dailyAuth)
+                .on(dailyChallenge.id.eq(dailyAuth.dailyChallenge.id)
+                        .and(memberEq(dailyAuth.member, loginMember))
+                        .and(todayEq(dailyAuth.updatedAt)))
+                .where(dailyChallenge.id.eq(challenge.getId())
+                        .and(dailyChallenge.challengeStatus.eq(ChallengeStatus.OPENED)))
+                .fetchOne();
+    }
+
+    @Override
+    public Page<DailyAuthImageResponse> findAllAuthList(
+            DailyChallenge dailyChallenge, Pageable pageable) {
+
+        List<DailyAuthImageResponse> content = queryFactory
+                .select(Projections.constructor(DailyAuthImageResponse.class,
+                        dailyAuth.dailyChallenge.id, dailyAuth.member.id,
+                        member.nickname, dailyAuth.imageUrl))
+                .from(dailyAuth)
+                .join(member) // cross join 방지
+                .on(dailyAuth.member.id.eq(member.id))
+                .where(dailyAuth.dailyChallenge.id.eq(dailyChallenge.getId())
+                        .and(todayEq(dailyAuth.updatedAt)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(dailyAuth.count())
+                .from(dailyAuth)
+                .where(dailyAuth.dailyChallenge.id.eq(dailyChallenge.getId())
+                        .and(todayEq(dailyAuth.updatedAt)));
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+
+    // 회원이 로그인 하지 않았을 때 on 절의 회원 비교를 하지 않는다. null 반환 = 비교 안함.
+    private BooleanExpression memberEq(QMember qMember, Member loginMember) {
+        return loginMember != null ? qMember.id.eq(loginMember.getId()) : null;
+    }
+
+    // LocaDateTime에서 시간 부분을 제외하고 날짜만 비교
+    private BooleanExpression todayEq(DateTimePath<LocalDateTime> dailyAuth) {
+        String todayStr = querydslFormatter.nowDateTimeToStr();
+        StringExpression authDate = querydslFormatter.formatter(dailyAuth);
+        return authDate.eq(todayStr);
+    }
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyAuthService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyAuthService.java
@@ -16,11 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
-import static com.itoxi.petnuri.global.common.exception.type.ErrorCode.NOT_FOUND_CHALLENGE_ID;
+import static com.itoxi.petnuri.global.common.exception.type.ErrorCode.NOT_FOUND_DAILY_CHALLENGE_ID;
 
 /**
  * author         : matrix
@@ -42,7 +38,7 @@ public class DailyAuthService {
 
         // 1. 챌린지 id 검증
         DailyChallenge dailyChallenge = dailyChallengeRepository.findById(challengeId)
-                .orElseThrow(() -> new Exception400(NOT_FOUND_CHALLENGE_ID));
+                .orElseThrow(() -> new Exception400(NOT_FOUND_DAILY_CHALLENGE_ID));
 
         // 2. 이미 인증글을 작성했다면 예외 던지기
         isDupeAuthMember(loginMember, dailyChallenge);
@@ -61,6 +57,7 @@ public class DailyAuthService {
 
         // 4. 회원의 포인트 적립을 위한 정보를 담아서 리턴
         return DailyAuthDto.builder()
+                .challengeId(dailyAuth.getId())
                 .payment(dailyChallenge.getPayment())
                 .authImageUrl(awsUrl)
                 .challengeTitle(dailyChallenge.getTitle())

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyChallengeService.java
@@ -4,15 +4,14 @@ import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyAuthImageRespon
 import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeDetailResponse;
 import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
 import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
-import com.itoxi.petnuri.domain.dailychallenge.repository.DailyAuthRepository;
 import com.itoxi.petnuri.domain.dailychallenge.repository.DailyChallengeRepository;
 import com.itoxi.petnuri.domain.member.entity.Member;
-import com.itoxi.petnuri.domain.member.repository.MemberRepository;
 import com.itoxi.petnuri.global.common.exception.Exception400;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -25,33 +24,33 @@ import static com.itoxi.petnuri.global.common.exception.type.ErrorCode.NOT_FOUND
  */
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DailyChallengeService {
 
     private final DailyChallengeRepository dailyChallengeRepository;
-    private final DailyAuthRepository dailyAuthRepository;
-    private final MemberRepository memberRepository;
 
     public List<DailyChallengeListResponse> respDailyChallengeList(Member loginMember) {
         // 반환에 필요한 데이터 : 챌린지 id, 챌리지명, 로그인한 유저의 참여 여부, 썸네일 url
-        return dailyChallengeRepository.findAllChallenge(loginMember);
+        return dailyChallengeRepository.findAllWithAuthStatus(loginMember);
     }
 
     public Page<DailyAuthImageResponse> respDailyChallengeAuthList(
-            Long dailyChallengeId, Member loginMember, Pageable pageable) {
-        DailyChallenge dailyChallenge = dailyChallengeRepository.findById(dailyChallengeId)
-                .orElseThrow(() -> new Exception400(NOT_FOUND_DAILY_CHALLENGE_ID));
-        dailyChallengeRepository.findAllByAuth(dailyChallenge, loginMember, pageable);
+            Long challengeId, Pageable pageable) {
 
-        return null;
+        DailyChallenge dailyChallenge = getChallengeById(challengeId);
+        return dailyChallengeRepository.findAllAuthList(dailyChallenge, pageable);
     }
 
     public DailyChallengeDetailResponse respDailyChallengeDetail(
-            Long dailyChallengeId, Member loginMember) {
-        DailyChallenge dailyChallenge = dailyChallengeRepository.findById(dailyChallengeId)
-                .orElseThrow(() -> new Exception400(NOT_FOUND_DAILY_CHALLENGE_ID));
-//        dailyChallengeRepository.findCha
+            Long challengeId, Member loginMember) {
 
-        return null;
+        DailyChallenge dailyChallenge = getChallengeById(challengeId);
+        return dailyChallengeRepository.findDetailChallenge(dailyChallenge, loginMember);
+    }
+
+    private DailyChallenge getChallengeById(Long challengeId) {
+        return dailyChallengeRepository.findById(challengeId)
+                .orElseThrow(() -> new Exception400(NOT_FOUND_DAILY_CHALLENGE_ID));
     }
 
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyChallengeService.java
@@ -1,17 +1,22 @@
 package com.itoxi.petnuri.domain.dailychallenge.service;
 
 import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyAuthImageResponse;
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeDetailResponse;
 import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
 import com.itoxi.petnuri.domain.dailychallenge.repository.DailyAuthRepository;
 import com.itoxi.petnuri.domain.dailychallenge.repository.DailyChallengeRepository;
 import com.itoxi.petnuri.domain.member.entity.Member;
 import com.itoxi.petnuri.domain.member.repository.MemberRepository;
+import com.itoxi.petnuri.global.common.exception.Exception400;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.NoSuchElementException;
+
+import static com.itoxi.petnuri.global.common.exception.type.ErrorCode.NOT_FOUND_DAILY_CHALLENGE_ID;
 
 /**
  * author         : Jisang Lee
@@ -28,20 +33,26 @@ public class DailyChallengeService {
 
     public List<DailyChallengeListResponse> respDailyChallengeList(Member loginMember) {
         // 반환에 필요한 데이터 : 챌린지 id, 챌리지명, 로그인한 유저의 참여 여부, 썸네일 url
-        Member member = memberRepository.findById(loginMember.getId())
-                .orElseThrow(NoSuchElementException::new);
-        System.out.printf("테스트 : loginMember = %d, %s%n", member.getId(), member.getNickname());
-
-        List<DailyChallengeListResponse> allWithMember = dailyChallengeRepository.listChallenge(loginMember);
-        for (DailyChallengeListResponse response : allWithMember) {
-            System.out.println(response);
-        }
-        return allWithMember;
+        return dailyChallengeRepository.findAllChallenge(loginMember);
     }
 
-    public Page<List<DailyAuthImageResponse>> respDailyChallengeAuthList(Long dailyChallengeId) {
+    public Page<DailyAuthImageResponse> respDailyChallengeAuthList(
+            Long dailyChallengeId, Member loginMember, Pageable pageable) {
+        DailyChallenge dailyChallenge = dailyChallengeRepository.findById(dailyChallengeId)
+                .orElseThrow(() -> new Exception400(NOT_FOUND_DAILY_CHALLENGE_ID));
+        dailyChallengeRepository.findAllByAuth(dailyChallenge, loginMember, pageable);
 
         return null;
     }
+
+    public DailyChallengeDetailResponse respDailyChallengeDetail(
+            Long dailyChallengeId, Member loginMember) {
+        DailyChallenge dailyChallenge = dailyChallengeRepository.findById(dailyChallengeId)
+                .orElseThrow(() -> new Exception400(NOT_FOUND_DAILY_CHALLENGE_ID));
+//        dailyChallengeRepository.findCha
+
+        return null;
+    }
+
 }
 

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/util/QuerydslDateTimeFormatter.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/util/QuerydslDateTimeFormatter.java
@@ -3,7 +3,6 @@ package com.itoxi.petnuri.domain.dailychallenge.util;
 import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.StringExpression;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -16,26 +15,29 @@ import java.time.format.DateTimeFormatter;
  * description    :
  */
 @Component
-@RequiredArgsConstructor
 public class QuerydslDateTimeFormatter {
-    // Todo: 서버 배포시 .yml에서 profiles 값을 읽어 오도록 코드 변경
+    // Todo: 서버 배포시 application.yml에서 profiles 값을 읽어 오도록 코드 변경 (test, dev, prod)
     @Value("${spring.datasource.driver-class-name}")
     private String dbName;
 
     public StringExpression formatter(DateTimePath<LocalDateTime> reqDateTime) {
-        StringExpression transferDate = null;
         if (dbName.contains("mysql")) {
-            // MySQL Expression
-            transferDate = Expressions.stringTemplate("FUNCTION('DATE_FORMAT', {0}, '%Y-%m-%d')", reqDateTime);
-        } else {
-            // H2 Expression
-            transferDate = Expressions.stringTemplate("FUNCTION('FORMATDATETIME', {0}, 'yyyy-MM-dd')", reqDateTime);
+            return getMySqlDate(reqDateTime);
         }
-        return transferDate;
+        return getH2Date(reqDateTime);
+    }
+
+    private StringExpression getH2Date(DateTimePath<LocalDateTime> reqDateTime) {
+        return Expressions.stringTemplate("FUNCTION('FORMATDATETIME', {0}, 'yyyy-MM-dd')", reqDateTime);
+    }
+
+    private StringExpression getMySqlDate(DateTimePath<LocalDateTime> reqDateTime) {
+        return Expressions.stringTemplate("FUNCTION('DATE_FORMAT', {0}, '%Y-%m-%d')", reqDateTime);
     }
 
     public String nowDateTimeToStr() {
         DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         return LocalDateTime.now().format(format);
     }
+
 }

--- a/src/main/java/com/itoxi/petnuri/domain/eventChallenge/service/RewardChallengeService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/eventChallenge/service/RewardChallengeService.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.itoxi.petnuri.domain.product.type.ChallengeProductCategory.REWARD;
-import static com.itoxi.petnuri.global.common.exception.type.ErrorCode.NOT_FOUND_CHALLENGE_ID;
+import static com.itoxi.petnuri.global.common.exception.type.ErrorCode.NOT_FOUND_DAILY_CHALLENGE_ID;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +28,7 @@ public class RewardChallengeService {
     @Transactional(readOnly = true)
     public GetRewardChallengeDetailResp getDetail(Long challengeId) {
         RewardChallenge rewardChallenge = challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new Exception404(NOT_FOUND_CHALLENGE_ID));
+                .orElseThrow(() -> new Exception404(NOT_FOUND_DAILY_CHALLENGE_ID));
 
         return new GetRewardChallengeDetailResp(rewardChallenge);
     }
@@ -36,7 +36,7 @@ public class RewardChallengeService {
     @Transactional(readOnly = true)
     public GetRewardChallengeProductResp getChallengeProduct(Long challengeId) {
         RewardChallenge rewardChallenge = challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new Exception404(NOT_FOUND_CHALLENGE_ID));
+                .orElseThrow(() -> new Exception404(NOT_FOUND_DAILY_CHALLENGE_ID));
 
         List<ChallengeProduct> challengeProducts = challengeProductRepository
                 .findAllByRewardChallengeAndCategory(rewardChallenge, REWARD);

--- a/src/main/java/com/itoxi/petnuri/domain/eventChallenge/service/RewardChallengerService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/eventChallenge/service/RewardChallengerService.java
@@ -41,7 +41,7 @@ public class RewardChallengerService {
     public GetMyRewardChallengeJoinResp getMyJoin(Member member, Long challengeId) {
         // 챌린지
         RewardChallenge rewardChallenge = challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new Exception404(NOT_FOUND_CHALLENGE_ID));
+                .orElseThrow(() -> new Exception404(NOT_FOUND_DAILY_CHALLENGE_ID));
 
         // 챌린지 참여
         RewardChallenger rewardChallenger = challengerRepository.findByChallengerAndRewardChallenge(member, rewardChallenge)
@@ -54,7 +54,7 @@ public class RewardChallengerService {
     public GetOtherRewardChallengeJoinResp getOtherJoin(Member member, Long challengeId) {
         // 챌린지
         RewardChallenge rewardChallenge = challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new Exception404(NOT_FOUND_CHALLENGE_ID));
+                .orElseThrow(() -> new Exception404(NOT_FOUND_DAILY_CHALLENGE_ID));
 
         List<GetOtherRewardChallengeJoinResp.JoinMemberDTO> JoinMembers = getJoinMembers(rewardChallenge, member);
         return new GetOtherRewardChallengeJoinResp(JoinMembers);
@@ -82,7 +82,7 @@ public class RewardChallengerService {
     public void create(Member member, Long challengeId, CreateChallengerReq request) {
         // 챌린지
         RewardChallenge rewardChallenge = challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new Exception404(NOT_FOUND_CHALLENGE_ID));
+                .orElseThrow(() -> new Exception404(NOT_FOUND_DAILY_CHALLENGE_ID));
 
         // 챌린지 신청 여부 검사. 이미 있으면 에러
         if (challengerRepository.existsByChallengerAndRewardChallenge(member, rewardChallenge)) {

--- a/src/main/java/com/itoxi/petnuri/global/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/itoxi/petnuri/global/common/exception/type/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     VALIDATION_ERROR("유효성 검사 중 예외가 발생했습니다."),
     S3UPLOADER_ERROR("s3 업로드 중 오류가 발생했습니다."),
     INVALID_FILE_REQUEST("유효하지 않은 파일이 전송되었습니다."), // 400
+    REQUIRED_LOGIN_ERROR("로그인을 해야 사용 가능한 메뉴입니다."),
 
 
     // REDIS

--- a/src/main/java/com/itoxi/petnuri/global/common/exception/type/ErrorCode.java
+++ b/src/main/java/com/itoxi/petnuri/global/common/exception/type/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
 
     // 챌린지
     NOT_FOUND_CHALLENGE_ID("유효하지 않은 챌린지 ID 입니다."),
+    NOT_FOUND_DAILY_CHALLENGE_ID("유효하지 않은 데일리 챌린지 ID 입니다."),
     NOT_FOUND_CHALLENGE_JOIN("챌린지 참여 내역이 존재하지 않습니다."),
     DUPE_CHALLENGE_JOIN("이미 챌린지 참여 내역이 존재합니다."),
     NOT_FOUND_CHALLENGE_KIT("챌린지에 등록된 검진 키트가 없습니다!"), //500 err

--- a/src/test/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImplTest.java
+++ b/src/test/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImplTest.java
@@ -1,0 +1,74 @@
+package com.itoxi.petnuri.domain.dailychallenge.repository;
+
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyAuth;
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-26
+ * description    :
+ */
+@SpringBootTest
+@Transactional
+class DailyAuthRepositoryImplTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private DailyAuthRepository dailyAuthRepository;
+
+    @Autowired
+    private DailyChallengeRepository dailyChallengeRepository;
+
+    @DisplayName("데일리 챌린지 중복 인증 방어 테스트")
+    @Test
+    public void dupePostByOneMember_and_querydslDateCompare_test() throws Exception {
+        // given
+        Member member1 = Member.createMember("tester1@test.copm", "tester1", "test1");
+        Member member2 = Member.createMember("tester2@test.copm", "tester2", "test2");
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+        DailyChallenge challenge1 = dailyChallengeRepository.findById(1L).orElseThrow(NoSuchElementException::new);
+
+        DailyAuth auth1 = DailyAuth.createDailyAuth(member1, challenge1, "https://test.url/test.jpng");
+        dailyAuthRepository.save(auth1);
+
+        // when
+        boolean result1 = dailyAuthRepository.dupePostCheck(member1, challenge1);
+        boolean result2 = dailyAuthRepository.dupePostCheck(member2, challenge1);
+        System.out.println("테스트 : result = " + result1);
+        System.out.println("테스트 : result = " + result2);
+
+        // then
+        assertThat(result1).isTrue();
+        assertThat(result2).isFalse();
+    }
+
+    @Test
+    public void authImagePage_test() throws Exception {
+        // given
+        Long challengeId = 1L;
+        DailyChallenge dailyChallenge = dailyChallengeRepository.findById(challengeId)
+                .orElseThrow(NoSuchElementException::new);
+//        Page<List<DailyAuth>> result = dailyAuthRepository.findAllByDailyChallengeId(dailyChallenge.getId());
+
+        // when
+
+        // then
+    }
+}

--- a/src/test/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryImplTest.java
+++ b/src/test/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryImplTest.java
@@ -1,0 +1,149 @@
+package com.itoxi.petnuri.domain.dailychallenge.repository;
+
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyAuthImageResponse;
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeDetailResponse;
+import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyAuth;
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
+import com.itoxi.petnuri.domain.member.entity.Member;
+import com.itoxi.petnuri.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * author         : Jisang Lee
+ * date           : 2023-09-26
+ * description    :
+ */
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class DailyChallengeRepositoryImplTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private DailyAuthRepository dailyAuthRepository;
+
+    @Autowired
+    private DailyChallengeRepository dailyChallengeRepository;
+
+    @DisplayName("챌린지 메인 화면 - 챌린지 목록 응답 테스트")
+    @Test
+    public void findAllChallenge_test() throws Exception {
+        // given
+        Member member1 = Member.createMember("tester1@test.copm", "tester1", "test1");
+        Member member2 = Member.createMember("tester2@test.copm", "tester2", "test2");
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+        DailyChallenge challenge1 = dailyChallengeRepository.findById(1L).orElseThrow(NoSuchElementException::new);
+        DailyChallenge challenge2 = dailyChallengeRepository.findById(2L).orElseThrow(NoSuchElementException::new);
+        DailyChallenge challenge3 = dailyChallengeRepository.findById(3L).orElseThrow(NoSuchElementException::new);
+
+        DailyAuth auth1 = DailyAuth.createDailyAuth(member1, challenge1, "https://test.url/test.jpng");
+        DailyAuth auth2 = DailyAuth.createDailyAuth(member1, challenge2, "https://test.url/test.jpng");
+        DailyAuth auth3 = DailyAuth.createDailyAuth(member1, challenge3, "https://test.url/test.jpng");
+        dailyAuthRepository.save(auth1);
+        dailyAuthRepository.save(auth2);
+        dailyAuthRepository.save(auth3);
+
+        // when
+        List<DailyChallengeListResponse> result1 = dailyChallengeRepository.findAllWithAuthStatus(member1);
+        List<DailyChallengeListResponse> result2 = dailyChallengeRepository.findAllWithAuthStatus(member2);
+
+        for (DailyChallengeListResponse response : result1) {
+            System.out.println("테스트 : challengeId = " + response.getChallengeId());
+            System.out.println("테스트 : title = " + response.getTitle());
+            System.out.println("테스트 : status = " + response.getStatus());
+            System.out.println("테스트 : thumbnail = " + response.getThumbnail());
+        }
+
+        System.out.println("==============================================================");
+
+        for (DailyChallengeListResponse response : result2) {
+            System.out.println("테스트 : challengeId = " + response.getChallengeId());
+            System.out.println("테스트 : title = " + response.getTitle());
+            System.out.println("테스트 : status = " + response.getStatus());
+            System.out.println("테스트 : thumbnail = " + response.getThumbnail());
+        }
+
+        // then
+        assertThat(result1.get(0).getStatus()).isTrue();
+        assertThat(result2.get(0).getStatus()).isFalse();
+    }
+
+    @DisplayName("데일리 챌린지 Detail view 응답 데이터 테스트")
+    @Test
+    public void findDetailChallenge_test() throws Exception {
+        // given
+        Member member1 = Member.createMember("tester1@test.copm", "tester1", "test1");
+        Member member2 = Member.createMember("tester2@test.copm", "tester2", "test2");
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+        DailyChallenge challenge1 = dailyChallengeRepository.findById(1L).orElseThrow(NoSuchElementException::new);
+
+        DailyAuth auth1 = DailyAuth.createDailyAuth(member1, challenge1, "https://test.url/test.jpng");
+        dailyAuthRepository.save(auth1);
+
+        // when
+        DailyChallengeDetailResponse response1 = dailyChallengeRepository.findDetailChallenge(challenge1, member1);
+        DailyChallengeDetailResponse response2 = dailyChallengeRepository.findDetailChallenge(challenge1, member2);
+
+        // then
+        assertThat(response1.getStatus()).isTrue();
+        assertThat(response2.getStatus()).isFalse();
+    }
+
+    @DisplayName("데일리 챌린지 디테일 view - 인증 사진 목록 응답 테스트")
+    @Test
+    public void findAllAuthList_test() throws Exception {
+        // given
+        Member member1 = Member.createMember("tester1@test.copm", "tester1", "test1");
+        Member member2 = Member.createMember("tester2@test.copm", "tester2", "test2");
+        Member member3 = Member.createMember("tester3@test.copm", "tester3", "test3");
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+        memberRepository.save(member3);
+
+        Long challengeId1 = 1L;
+        DailyChallenge challenge1 = dailyChallengeRepository.findById(challengeId1).orElseThrow(NoSuchElementException::new);
+
+        DailyAuth auth1 = DailyAuth.createDailyAuth(member1, challenge1, "https://test.url/test.jpng");
+        DailyAuth auth2 = DailyAuth.createDailyAuth(member2, challenge1, "https://test.url/test.jpng");
+        DailyAuth auth3 = DailyAuth.createDailyAuth(member3, challenge1, "https://test.url/test.jpng");
+        dailyAuthRepository.save(auth1);
+        dailyAuthRepository.save(auth2);
+        dailyAuthRepository.save(auth3);
+
+        // when
+        Pageable pageable = PageRequest.of(0, 5);
+        Page<DailyAuthImageResponse> responses = dailyChallengeRepository.findAllAuthList(challenge1, pageable);
+
+        for (DailyAuthImageResponse respons : responses) {
+            System.out.println("테스트 : challengeId =  " + respons.getChallengeId());
+            System.out.println("테스트 : memberId = " + respons.getMemberId());
+            System.out.println("테스트 : nickName = " + respons.getNickName());
+            System.out.println("테스트 : imageUrl = " + respons.getImageUrl());
+            System.out.println("----------------------------------------------------------------");
+        }
+
+        // then
+        assertThat(responses.getTotalElements()).isEqualTo(3);
+    }
+
+}


### PR DESCRIPTION
## 요약
데일리 챌린지 인증 사진 목록 응답 api 구현

## 작업 내용
- 데일리 챌린지 인증 사진 목록 응답 api 구현
- 기타 코드 refactoring (커밋 목록 참조)

## 참고 사항

## 관련 이슈
Close #115 
