### PR TITLE
[#128] feat: 데일리 챌린지 스케줄러 기능 추가 구현

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyChallengeAdminController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyChallengeAdminController.java
@@ -43,4 +43,5 @@ public class DailyChallengeAdminController {
             throw new Exception400(INVALID_FILE_REQUEST);
         }
     }
+
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/entity/DailyChallenge.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/entity/DailyChallenge.java
@@ -4,16 +4,10 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.itoxi.petnuri.domain.dailychallenge.dto.request.DailyChallengeRequest;
 import com.itoxi.petnuri.domain.dailychallenge.type.ChallengeStatus;
 import com.itoxi.petnuri.global.common.BaseTimeEntity;
+import lombok.*;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import javax.persistence.*;
-
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.time.LocalDate;
 /**
  * author         : matrix
  * date           : 2023-09-13
@@ -67,6 +61,11 @@ public class DailyChallenge extends BaseTimeEntity {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate;      // 챌린지 종료 일자 : 9999-12-31 23:59:59
 
+    public DailyChallenge changeStatus(ChallengeStatus challengeStatus) {
+        this.challengeStatus = challengeStatus;
+        return this;
+    }
+
     public static DailyChallenge toEntity(DailyChallengeRequest request, String thumbnail, String banner) {
         return DailyChallenge.builder()
                 .title(request.getTitle())
@@ -81,4 +80,5 @@ public class DailyChallenge extends BaseTimeEntity {
                 .endDate(LocalDate.of(9999,12,31))
                 .build();
     }
+
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepository.java
@@ -3,11 +3,15 @@ package com.itoxi.petnuri.domain.dailychallenge.repository;
 import com.itoxi.petnuri.domain.dailychallenge.entity.DailyAuth;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 /**
  * author         : matrix
  * date           : 2023-09-16
  * description    :
  */
 public interface DailyAuthRepository extends JpaRepository<DailyAuth, Long>, DailyAuthRepositoryCustom {
-    
+
+    long deleteDailyAuthByUpdatedAtBefore(LocalDateTime today);
+
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryCustom.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryCustom.java
@@ -1,8 +1,5 @@
 package com.itoxi.petnuri.domain.dailychallenge.repository;
 
-import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
-import com.itoxi.petnuri.domain.member.entity.Member;
-
 /**
  * author         : Jisang Lee
  * date           : 2023-09-26
@@ -11,7 +8,5 @@ import com.itoxi.petnuri.domain.member.entity.Member;
 public interface DailyAuthRepositoryCustom {
 
     boolean dupeAuthCheck(Long memberId, Long dailyChallengeId);
-
-    Long deleteAuthDataByDate();
 
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImpl.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImpl.java
@@ -1,10 +1,8 @@
 package com.itoxi.petnuri.domain.dailychallenge.repository;
 
 import com.itoxi.petnuri.domain.dailychallenge.entity.QDailyAuth;
-import com.itoxi.petnuri.domain.dailychallenge.util.QuerydslDateTimeFormatter;
 import com.itoxi.petnuri.domain.member.entity.Member;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.DateTemplate;
 import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -21,38 +19,22 @@ import java.time.LocalDateTime;
 public class DailyAuthRepositoryImpl implements DailyAuthRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
-    private final QuerydslDateTimeFormatter querydslFormatter;
-
     QDailyAuth dailyAuth = QDailyAuth.dailyAuth;
 
     @Override
     public boolean dupeAuthCheck(Long loginMemberId, Long dailyChallengeId) {
-        Member result = queryFactory
+        Member member = queryFactory
                 .select(dailyAuth.member)
                 .from(dailyAuth)
                 .where(dailyAuth.dailyChallenge.id.eq(dailyChallengeId)
                         .and(dailyAuth.member.id.eq(loginMemberId))
-                        .and(eqToday(dailyAuth.updatedAt)))
+                        .and(goeToday(dailyAuth.updatedAt)))
                 .fetchOne();
-        return (result != null) ? true : false; // true : 중복 인증
+        return (member != null) ? true : false; // true : 중복 인증
     }
 
-    @Override
-    public Long deleteAuthDataByDate() {
-        return queryFactory
-                .delete(dailyAuth)
-                .where(ltToday(dailyAuth.updatedAt))
-                .execute();
-    }
-
-    private BooleanExpression eqToday(DateTimePath<LocalDateTime> dailyAuth) {
-        DateTemplate<LocalDate> authDate = querydslFormatter.formatter(dailyAuth);
-        return authDate.eq(LocalDate.now());
-    }
-
-    private BooleanExpression ltToday(DateTimePath<LocalDateTime> dailyAuth) {
-        DateTemplate<LocalDate> authDate = querydslFormatter.formatter(dailyAuth);
-        return authDate.lt(LocalDate.now());
+    private BooleanExpression goeToday(DateTimePath<LocalDateTime> compareDate) {
+        return compareDate.goe(LocalDate.now().atStartOfDay());
     }
 
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepository.java
@@ -4,6 +4,8 @@ import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
 import com.itoxi.petnuri.domain.dailychallenge.type.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -16,5 +18,8 @@ public interface DailyChallengeRepository extends JpaRepository<DailyChallenge, 
     boolean existsByIdAndChallengeStatus(Long challengeId, ChallengeStatus status);
 
     Optional<DailyChallenge> findByIdAndChallengeStatus(Long challengeId, ChallengeStatus status);
+
+    List<DailyChallenge> findByChallengeStatusAndStartDateEquals(
+            ChallengeStatus challengeStatus, LocalDate today);
 
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryCustom.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryCustom.java
@@ -3,7 +3,6 @@ package com.itoxi.petnuri.domain.dailychallenge.repository;
 import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyAuthImageResponse;
 import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeDetailResponse;
 import com.itoxi.petnuri.domain.dailychallenge.dto.response.DailyChallengeListResponse;
-import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
 import com.itoxi.petnuri.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,7 +16,7 @@ import java.util.List;
  */
 public interface DailyChallengeRepositoryCustom {
 
-    List<DailyChallengeListResponse> findAllWithAuthStatus(Member loginMember);
+    List<DailyChallengeListResponse> findAllAuthStatus(Member loginMember);
 
     Page<DailyAuthImageResponse> findAllAuthList(
             Long dailyChallengeId, Pageable pageable);

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyAuthService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyAuthService.java
@@ -56,7 +56,6 @@ public class DailyAuthService {
     }
 
     private void isDupeAuthMember(Long loginMemberId, Long dailyChallengeId) {
-        // Todo: 날짜 체크를 우선 query에서 비교하도록 구현하였음.
         if (dailyAuthRepository.dupeAuthCheck(loginMemberId, dailyChallengeId)) {
             throw new Exception400(ErrorCode.DUPE_POST_MEMBER);
         }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyChallengeService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/service/DailyChallengeService.java
@@ -36,7 +36,7 @@ public class DailyChallengeService {
 
     public List<DailyChallengeListResponse> respDailyChallengeList(Member loginMember) {
         // 반환에 필요한 데이터 : 챌린지 id, 챌리지명, 로그인한 유저의 참여 여부, 썸네일 url
-        return dailyChallengeRepository.findAllWithAuthStatus(loginMember);
+        return dailyChallengeRepository.findAllAuthStatus(loginMember);
     }
 
     public Page<DailyAuthImageResponse> respDailyChallengeAuthList(

--- a/src/main/java/com/itoxi/petnuri/global/scheduler/DailyAuthScheduler.java
+++ b/src/main/java/com/itoxi/petnuri/global/scheduler/DailyAuthScheduler.java
@@ -1,14 +1,18 @@
 package com.itoxi.petnuri.global.scheduler;
 
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
 import com.itoxi.petnuri.domain.dailychallenge.repository.DailyAuthRepository;
+import com.itoxi.petnuri.domain.dailychallenge.repository.DailyChallengeRepository;
+import com.itoxi.petnuri.domain.dailychallenge.type.ChallengeStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * author         : Jisang Lee
@@ -18,20 +22,35 @@ import java.time.LocalDateTime;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class DailyAuthScheduler {
 
     private final DailyAuthRepository dailyAuthRepository;
-    private final EntityManager em;
+    private final DailyChallengeRepository dailyChallengeRepository;
 
     // Todo: S3 파일 삭제는 S3 서버에서 설정.
-    @Transactional
     @Scheduled(cron = "${scheduler.daily-challenge.cron}")
-    public Long deleteDailyAuthDataByDate() {
-        Long deletedCount = dailyAuthRepository.deleteAuthDataByDate();
-        log.info(deletedCount + " 건 삭제 완료. " + LocalDateTime.now());
-        
-        em.flush();
-        em.clear();
-        return deletedCount;
+    public void deleteDailyAuthDataByTodayBefore() {
+        dailyAuthRepository.deleteDailyAuthByUpdatedAtBefore(
+                LocalDate.now().atStartOfDay());
+        log.info(LocalDate.now() + "일자 이전의 인증글이 삭제 되었습니다. " + LocalDateTime.now());
     }
+
+    @Scheduled(cron = "${scheduler.daily-challenge.cron}")
+    public long openDailyChallengeByStartDateAfter() {
+        List<DailyChallenge> results = dailyChallengeRepository
+                .findByChallengeStatusAndStartDateEquals(
+                        ChallengeStatus.READY, LocalDate.now());
+        long count = results.size();
+
+        if (results.size() < 1) {
+            log.info("오픈 예정인 데일리 챌린지가 없습니다. " + LocalDateTime.now());
+            return count;
+        }
+
+        results.forEach(result -> result.changeStatus(ChallengeStatus.OPENED));
+        log.info(count + " 건의 데일리 챌린지가 OPEN 되었습니다. " + LocalDateTime.now());
+        return count;
+    }
+
 }

--- a/src/main/resources/table/h2/data.sql
+++ b/src/main/resources/table/h2/data.sql
@@ -25,9 +25,11 @@ values ('간식주기 챌린지', '반려동물에게 간식주는 사진을 인
         'https://www.test.url/thumbnail.jpg', 'https://test.url/banner.jpg',
         '2023-09-16', '9999-12-31', 'OPENED', now(), now());
 
--- 데일리 챌린지 인증글 더미 데이터 생성(스케줄러 삭제 테스트용)
+-- 데일리 챌린지 인증글 더미 데이터 생성
 insert into daily_auth(member_id, daily_challenge_id, image_url, created_at, updated_at)
-values (1, 1, 'https://www.test.url/auth.jpg', '2023-09-16', '2023-09-16');
+values (1, 1, 'https://www.test.url/auth.jpg', CURRENT_DATE - 1, CURRENT_DATE - 1);
+insert into daily_auth(member_id, daily_challenge_id, image_url, created_at, updated_at)
+values (1, 1, 'https://www.test.url/auth.jpg', now(), now());
 
 insert into reward_challenge (title, sub_title, notice, thumbnail, poster, status, start_date, end_date,
                               kit_start_date, kit_end_date, review_start_date, review_end_date, created_at, updated_at)

--- a/src/test/java/com/itoxi/petnuri/global/scheduler/DailyAuthSchedulerTest.java
+++ b/src/test/java/com/itoxi/petnuri/global/scheduler/DailyAuthSchedulerTest.java
@@ -1,10 +1,19 @@
 package com.itoxi.petnuri.global.scheduler;
 
+import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
+import com.itoxi.petnuri.domain.dailychallenge.repository.DailyAuthRepository;
+import com.itoxi.petnuri.domain.dailychallenge.repository.DailyChallengeRepository;
+import com.itoxi.petnuri.domain.dailychallenge.type.ChallengeStatus;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,15 +30,62 @@ class DailyAuthSchedulerTest {
 
     @Autowired
     private DailyAuthScheduler dailyAuthScheduler;
+    @Autowired
+    private DailyChallengeRepository dailyChallengeRepository;
+    @Autowired
+    private DailyAuthRepository dailyAuthRepository;
+    @Autowired
+    private EntityManager em;
 
+    @DisplayName("하루 이상 지난 인증글 삭제 테스트")
     @Test
-    public void scheduler_test() {
+    @Sql(scripts = {"classpath:create_auth.sql"})
+    public void dailyAuthDelete_test() {
+        // Given
+        long count = dailyAuthRepository.count();
+        System.out.println("테스트 : Current auth data count = " + count);
+
+        // When & Then
         await()
                 .atMost(3, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
-                    Long result = dailyAuthScheduler.deleteDailyAuthDataByDate();
-                    assertThat(result).isGreaterThan(0);
+                    dailyAuthScheduler.deleteDailyAuthDataByTodayBefore();
+                    long result = dailyAuthRepository.count();
+                    assertThat(result).isEqualTo(0);
                 });
+    }
+
+    @DisplayName("READY 상태인 데일리 챌린지 OPENED 업데이트 테스트")
+    @Test
+    public void dailyChallengeUpdate_test() throws Exception {
+        // given
+        DailyChallenge dailyChallenge = DailyChallenge.builder()
+                .title("놀아주기 챌린지")
+                .subTitle("반려동물에게 간식주는 사진을 인증해요!")
+                .authMethod("인증 사진 업로드!")
+                .payment(100L)
+                .paymentMethod("참여완료 즉시 지급")
+                .thumbnail("https://www.test.url/thumbnail.jpg")
+                .banner("https://www.test.url/banner.jpg")
+                .challengeStatus(ChallengeStatus.READY)
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.of(9999, 12, 31))
+                .build();
+        dailyChallengeRepository.save(dailyChallenge);
+        em.flush();
+        em.clear();
+
+        // when
+        long result = dailyAuthScheduler.openDailyChallengeByStartDateAfter();
+        DailyChallenge challenge = dailyChallengeRepository.findById(dailyChallenge.getId())
+                .orElseThrow(NoSuchElementException::new);
+
+        // then
+        System.out.println("테스트 : result = " + result);
+        System.out.println("테스트 : status = " + challenge.getChallengeStatus());
+        assertThat(result).isGreaterThan(0);
+        assertThat(challenge.getChallengeStatus()).isEqualTo(ChallengeStatus.OPENED);
+
     }
 
 }

--- a/src/test/resources/create_auth.sql
+++ b/src/test/resources/create_auth.sql
@@ -1,0 +1,3 @@
+-- create_auth
+insert into daily_auth(member_id, daily_challenge_id, image_url, created_at, updated_at)
+values (1, 1, 'https://www.test.url/auth.jpg', CURRENT_DATE - 1, CURRENT_DATE - 1);


### PR DESCRIPTION
## 요약
데일리 챌린지 스케줄러 기능 추가 구현

## 작업 내용
- 데일리 챌린지 스케줄러 기능 추가 구현
- 데일리 챌린지 스케줄러 테스트
- Querydsl 인증글 작성 날짜 비교 루틴 수정
- 로그인 하지 않은 회원의 인증글 작성 여부가 작성으로 응답되던 버그를 수정
- 기타 코드 정리

## 참고 사항
커밋 메시지 참조

## 관련 이슈
Close #128 
