### PR TITLE
[#148] 데일리 인증글 작성 시 시큐리티 필터 적용

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyAuthController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyAuthController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -32,6 +33,7 @@ public class DailyAuthController {
     private final DailyAuthService dailyAuthService;
     private final PointService pointService;
 
+    @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping(path ="/{challengeId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<DailyAuthResponse> saveAuth(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
@@ -41,7 +43,7 @@ public class DailyAuthController {
         isNotEmptyFile(file); // 업로드한 파일의 유효성 검사
 
         // Todo: 차후 시큐리티 로직이 완성되면 로직 제거 -> 로그인 유도로 대체
-        Member loginMember = isLoginMember(principalDetails); // NPE 방지
+        Member loginMember = principalDetails.getMember();
 
         // 1. 인증 글 등록 후 포인트 적립을 위한 데이터 받아 오기
         DailyAuthDto dailyAuthDto = dailyAuthService.saveAuth(loginMember, challengeId, file);
@@ -57,13 +59,6 @@ public class DailyAuthController {
         if (file.isEmpty() || file == null) {
             throw new Exception400(INVALID_FILE_REQUEST);
         }
-    }
-
-    private Member isLoginMember(PrincipalDetails principalDetails) {
-        if (principalDetails == null) { // NullPointerException 방지
-            throw new Exception400(REQUIRED_LOGIN_ERROR);
-        }
-        return principalDetails.getMember();
     }
 
 }

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
@@ -102,10 +102,10 @@ public class DailyChallengeRepositoryImpl implements DailyChallengeRepositoryCus
     }
 
 
-    // 회원이 로그인 하지 않았다면 인증글 작성 여부를 false가 되도록 리턴.
+    // 로그인 하지 않은 유저는 존재할 수 없는 id 0과 비교.
     private BooleanExpression memberEq(QMember qMember, Member loginMember) {
         if (loginMember == null) {
-            return qMember.isNull();
+            return qMember.id.eq(0L);
         }
         return qMember.id.eq(loginMember.getId());
     }


### PR DESCRIPTION
## 요약
[#148] 데일리 인증글 작성 시 시큐리티 필터 적용

## 작업 내용
- 인증글 작성 시 로그인 필터 적용
- 로그인 하지 않은 회원의 인증글 작성 여부 검사 로직 수정
- 
## 참고 사항

## 관련 이슈
Close #148
