### PR TITLE
[#162] fix: emojiCount, replyCount 0L 초기화

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/entity/PetTalk.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/entity/PetTalk.java
@@ -74,10 +74,10 @@ public class PetTalk extends BaseTimeEntity {
     private boolean reacted; // 로그인된 사용자 이모지 반응 boolean 값
 
     @Transient
-    private Long emojiCount;
+    private Long emojiCount = 0L;
 
     @Transient
-    private Long replyCount;
+    private Long replyCount = 0L;
 
     public static PetTalk createByChallengeReview(
             Member member, String challengeTitle, String content, MainCategory mainCategory, PetType petType
@@ -97,17 +97,17 @@ public class PetTalk extends BaseTimeEntity {
     }
 
     public PetTalk addEmojiCount() {
-        this.emojiCount += 1;
+        this.emojiCount += 1L;
         return this;
     }
 
     public PetTalk subtractEmojiCount() {
-        this.emojiCount -= 1;
+        this.emojiCount -= 1L;
         return this;
     }
 
     public PetTalk addReplyCount() {
-        this.replyCount += 1;
+        this.replyCount += 1L;
         return this;
     }
 


### PR DESCRIPTION
## 요약
emojiCount, replyCount 카운트 증가, 감소 시 NullPointerException 발생
초기화가 안되어 있기 때문

## 작업 내용

- [x] 0L 로 초기화
- [x] 카운트 증가, 감소 시키는 부분에도 L 단위 추가 

## 참고 사항

## 관련 이슈
Close #162
