### PR TITLE
[#164] fix: getOtherJoin 토큰 요청, 본인 필터링 로직 제거

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/eventChallenge/controller/RewardChallengerController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/eventChallenge/controller/RewardChallengerController.java
@@ -34,14 +34,11 @@ public class RewardChallengerController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/{challengeId}/join/other")
     public ResponseEntity<GetOtherRewardChallengeJoinResp> getOtherJoin(
-            @PathVariable @ValidId Long challengeId,
-            @AuthenticationPrincipal PrincipalDetails principalDetails
+            @PathVariable @ValidId Long challengeId
     ) {
-        Member member = principalDetails.getMember();
-        GetOtherRewardChallengeJoinResp response = rewardChallengerService.getOtherJoin(member, challengeId);
+        GetOtherRewardChallengeJoinResp response = rewardChallengerService.getOtherJoin(challengeId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/itoxi/petnuri/domain/eventChallenge/repository/RewardChallengeReviewRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/eventChallenge/repository/RewardChallengeReviewRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 public interface RewardChallengeReviewRepository extends JpaRepository<RewardChallengeReview, Long> {
     boolean existsByChallengerAndRewardChallengeId(Member challenger, Long rewardChallengeId);
 
-    List<RewardChallengeReview> findAllByRewardChallengeAndChallengerNot(RewardChallenge rewardChallenge, Member challenger);
+    List<RewardChallengeReview> findAllByRewardChallenge(RewardChallenge rewardChallenge);
 }

--- a/src/main/java/com/itoxi/petnuri/domain/eventChallenge/repository/RewardChallengerRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/eventChallenge/repository/RewardChallengerRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public interface RewardChallengerRepository extends JpaRepository<RewardChallenger, Long> {
     Optional<RewardChallenger> findByChallengerAndRewardChallenge(Member challenger, RewardChallenge rewardChallenge);
 
-    List<RewardChallenger> findAllByRewardChallengeAndChallengerNot(RewardChallenge rewardChallenge, Member challenger);
+    List<RewardChallenger> findAllByRewardChallenge(RewardChallenge rewardChallenge);
 
     boolean existsByChallengerAndRewardChallenge(Member challenger, RewardChallenge rewardChallenge);
 }

--- a/src/main/java/com/itoxi/petnuri/domain/eventChallenge/service/RewardChallengerService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/eventChallenge/service/RewardChallengerService.java
@@ -51,27 +51,27 @@ public class RewardChallengerService {
     }
 
     @Transactional(readOnly = true)
-    public GetOtherRewardChallengeJoinResp getOtherJoin(Member member, Long challengeId) {
+    public GetOtherRewardChallengeJoinResp getOtherJoin(Long challengeId) {
         // 챌린지
         RewardChallenge rewardChallenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new Exception404(NOT_FOUND_CHALLENGE_ID));
 
-        List<GetOtherRewardChallengeJoinResp.JoinMemberDTO> JoinMembers = getJoinMembers(rewardChallenge, member);
+        List<GetOtherRewardChallengeJoinResp.JoinMemberDTO> JoinMembers = getJoinMembers(rewardChallenge);
         return new GetOtherRewardChallengeJoinResp(JoinMembers);
     }
 
     @Transactional(readOnly = true)
-    public List<GetOtherRewardChallengeJoinResp.JoinMemberDTO> getJoinMembers(RewardChallenge rewardChallenge, Member member) {
+    public List<GetOtherRewardChallengeJoinResp.JoinMemberDTO> getJoinMembers(RewardChallenge rewardChallenge) {
         LocalDateTime now = LocalDateTime.now();
         if (now.isBefore(rewardChallenge.getReviewStartDate())) {
             // 신청 ~ 키트 수령기간
-            List<RewardChallenger> challengers = challengerRepository.findAllByRewardChallengeAndChallengerNot(rewardChallenge, member);
+            List<RewardChallenger> challengers = challengerRepository.findAllByRewardChallenge(rewardChallenge);
             return challengers.stream()
                     .map(GetOtherRewardChallengeJoinResp.JoinMemberDTO::new)
                     .collect(Collectors.toList());
         } else {
             // 리뷰 작성 기간
-            List<RewardChallengeReview> reviews = reviewRepository.findAllByRewardChallengeAndChallengerNot(rewardChallenge, member);
+            List<RewardChallengeReview> reviews = reviewRepository.findAllByRewardChallenge(rewardChallenge);
             return reviews.stream()
                     .map(GetOtherRewardChallengeJoinResp.JoinMemberDTO::new)
                     .collect(Collectors.toList());

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/controller/PetTalkPostController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/controller/PetTalkPostController.java
@@ -3,7 +3,6 @@ package com.itoxi.petnuri.domain.petTalk.controller;
 import com.itoxi.petnuri.domain.petTalk.dto.request.WritePetTalkRequest;
 import com.itoxi.petnuri.domain.petTalk.dto.response.LoadPetTalkPostDetailsResponse;
 import com.itoxi.petnuri.domain.petTalk.dto.response.LoadPetTalkPostsResponse;
-import com.itoxi.petnuri.domain.petTalk.entity.PetTalk;
 import com.itoxi.petnuri.domain.petTalk.entity.PetTalkView;
 import com.itoxi.petnuri.domain.petTalk.service.PetTalkService;
 import com.itoxi.petnuri.domain.petTalk.type.OrderType;
@@ -17,14 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -37,7 +29,7 @@ public class PetTalkPostController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<Object> write(
-            @RequestPart MultipartFile[] files,
+            @RequestPart(required = false) MultipartFile[] files,
             @RequestPart WritePetTalkRequest request,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
         petTalkService.write(principalDetails, files, request);

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/dto/request/WritePetTalkReplyReq.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/dto/request/WritePetTalkReplyReq.java
@@ -2,14 +2,14 @@ package com.itoxi.petnuri.domain.petTalk.dto.request;
 
 import lombok.Getter;
 
-import javax.validation.constraints.Max;
 import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
 
 @Getter
 public class WritePetTalkReplyReq {
     @PositiveOrZero
     private Long parentId;
 
-    @Max(500)
+    @Size(max = 500, message = "글자수는 500자 이하여야 합니다.")
     private String content;
 }


### PR DESCRIPTION
## 요약
타 유저 참여 현황 조회 시 본인 필터링 로직을 토큰을 받아 서버에서 수행했는데
비회원인 경우도 참여 현황이 보여야 한다고 함.
토큰을 받지 않고 필터링 없이 응답하면 프론트에서 필터링 처리 하기로 함

## 작업 내용
- [x] 토큰 요청 제거
- [x] 본인 필터링 로직 제거 

## 참고 사항

## 관련 이슈
Close #164
Close #166