### PR TITLE
[#176] refactor:  중복 인증글 작성 방어 로직 개선

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyAuthController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/controller/DailyAuthController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import static com.itoxi.petnuri.global.common.exception.type.ErrorCode.INVALID_FILE_REQUEST;
-import static com.itoxi.petnuri.global.common.exception.type.ErrorCode.REQUIRED_LOGIN_ERROR;
 
 /**
  * author         : matrix

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImpl.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.itoxi.petnuri.domain.dailychallenge.repository;
 
 import com.itoxi.petnuri.domain.dailychallenge.entity.QDailyAuth;
-import com.itoxi.petnuri.domain.member.entity.Member;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -23,14 +22,15 @@ public class DailyAuthRepositoryImpl implements DailyAuthRepositoryCustom {
 
     @Override
     public boolean dupeAuthCheck(Long loginMemberId, Long dailyChallengeId) {
-        Member member = queryFactory
-                .select(dailyAuth.member)
+        return queryFactory
+                .selectOne()
                 .from(dailyAuth)
-                .where(dailyAuth.dailyChallenge.id.eq(dailyChallengeId)
-                        .and(dailyAuth.member.id.eq(loginMemberId))
-                        .and(goeToday(dailyAuth.updatedAt)))
-                .fetchOne();
-        return (member != null) ? true : false; // true : 중복 인증
+                .where(
+                        dailyAuth.dailyChallenge.id.eq(dailyChallengeId),
+                        dailyAuth.member.id.eq(loginMemberId),
+                        goeToday(dailyAuth.updatedAt)
+                )
+                .fetchFirst() != null; // true : 중복 인증
     }
 
     private BooleanExpression goeToday(DateTimePath<LocalDateTime> compareDate) {

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepository.java
@@ -4,8 +4,6 @@ import com.itoxi.petnuri.domain.dailychallenge.entity.DailyChallenge;
 import com.itoxi.petnuri.domain.dailychallenge.type.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 
 /**

--- a/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
+++ b/src/main/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyChallengeRepositoryImpl.java
@@ -45,7 +45,7 @@ public class DailyChallengeRepositoryImpl implements DailyChallengeRepositoryCus
         return queryFactory
                 .select(Projections.constructor(DailyChallengeListResponse.class,
                         dailyChallenge.id, dailyChallenge.title,
-                        dailyChallenge.thumbnail, dailyAuth.member.isNotNull()))
+                        dailyChallenge.thumbnail, dailyAuth.member.id.isNotNull()))
                 .from(dailyChallenge)
                 .leftJoin(dailyAuth)
                 .on(dailyChallenge.id.eq(dailyAuth.dailyChallenge.id)
@@ -63,7 +63,7 @@ public class DailyChallengeRepositoryImpl implements DailyChallengeRepositoryCus
                 .select(Projections.constructor(DailyChallengeDetailResponse.class,
                         dailyChallenge.id, dailyChallenge.banner, dailyChallenge.title,
                         dailyChallenge.subTitle, dailyChallenge.authMethod, dailyChallenge.payment,
-                        dailyChallenge.paymentMethod, dailyAuth.member.isNotNull()))
+                        dailyChallenge.paymentMethod, dailyAuth.member.id.isNotNull()))
                 .from(dailyChallenge)
                 .leftJoin(dailyAuth)
                 .on(dailyChallenge.id.eq(dailyAuth.dailyChallenge.id)

--- a/src/main/java/com/itoxi/petnuri/domain/point/controller/PointController.java
+++ b/src/main/java/com/itoxi/petnuri/domain/point/controller/PointController.java
@@ -2,14 +2,12 @@ package com.itoxi.petnuri.domain.point.controller;
 
 import com.itoxi.petnuri.domain.point.dto.response.PointResponse;
 import com.itoxi.petnuri.domain.point.service.PointService;
-import com.itoxi.petnuri.global.common.customValid.valid.ValidId;
 import com.itoxi.petnuri.global.security.auth.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/itoxi/petnuri/global/s3/service/AmazonS3Service.java
+++ b/src/main/java/com/itoxi/petnuri/global/s3/service/AmazonS3Service.java
@@ -201,15 +201,4 @@ public class AmazonS3Service {
         return amazonS3.getUrl(bucket, fileKey).toString();
     }
 
-    // S3 deleteObject()의 filename 생성용
-    private String getFileNameFromUrl(String url) {
-        // 1. amazonaws.com 이 위치한 문자열 index를 가져온다.
-        int startIndex = url.indexOf(".com");
-
-        // 2. startIndex에서부터 처음 나오는 "/"의 위치 다움 문자 인덱스를 가져 온다.
-        int fromIndex = url.indexOf("/", startIndex) + 1;
-
-        // 3. fromIndex부터 끝까지 문자열을 잘라서 filename을 만들어서 반환.
-        return url.substring(fromIndex, url.length());
-    }
 }

--- a/src/main/java/com/itoxi/petnuri/global/scheduler/DailyAuthScheduler.java
+++ b/src/main/java/com/itoxi/petnuri/global/scheduler/DailyAuthScheduler.java
@@ -30,10 +30,15 @@ public class DailyAuthScheduler {
 
     // Todo: S3 파일 삭제는 S3 서버에서 설정.
     @Scheduled(cron = "${scheduler.daily-challenge.cron}")
-    public void deleteDailyAuthDataByTodayBefore() {
-        dailyAuthRepository.deleteDailyAuthByUpdatedAtBefore(
+    public long deleteDailyAuthDataByTodayBefore() {
+        long result = dailyAuthRepository.deleteDailyAuthByUpdatedAtBefore(
                 LocalDate.now().atStartOfDay());
-        log.info(LocalDate.now() + "일자 이전의 인증글이 삭제 되었습니다. " + LocalDateTime.now());
+        if (result == 0) {
+            log.info(LocalDate.now() + "일 이전의 삭제된 인증글이 없습니다. " + LocalDateTime.now());
+        } else {
+            log.info(LocalDate.now() + "일 이전의 인증글이 삭제되었습니다. " + LocalDateTime.now());
+        }
+        return result;
     }
 
     @Scheduled(cron = "${scheduler.daily-challenge.cron}")

--- a/src/test/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImplTest.java
+++ b/src/test/java/com/itoxi/petnuri/domain/dailychallenge/repository/DailyAuthRepositoryImplTest.java
@@ -7,11 +7,10 @@ import com.itoxi.petnuri.domain.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * date           : 2023-09-26
  * description    :
  */
-@SpringBootTest
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @Transactional
 class DailyAuthRepositoryImplTest {
 

--- a/src/test/java/com/itoxi/petnuri/global/scheduler/DailyAuthSchedulerTest.java
+++ b/src/test/java/com/itoxi/petnuri/global/scheduler/DailyAuthSchedulerTest.java
@@ -7,6 +7,7 @@ import com.itoxi.petnuri.domain.dailychallenge.type.ChallengeStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +25,9 @@ import static org.awaitility.Awaitility.await;
  * date           : 2023-10-01
  * description    :
  */
-@SpringBootTest(properties = {"scheduler.daily-challenge.cron=1 * * * * *"})
+@AutoConfigureMockMvc
+@SpringBootTest(properties = {"scheduler.daily-challenge.cron=1 * * * * *"},
+        webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @Transactional
 class DailyAuthSchedulerTest {
 
@@ -49,9 +52,8 @@ class DailyAuthSchedulerTest {
         await()
                 .atMost(3, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
-                    dailyAuthScheduler.deleteDailyAuthDataByTodayBefore();
-                    long result = dailyAuthRepository.count();
-                    assertThat(result).isEqualTo(0);
+                    long result = dailyAuthScheduler.deleteDailyAuthDataByTodayBefore();
+                    assertThat(result).isEqualTo(1);
                 });
     }
 


### PR DESCRIPTION
## 요약
중복 인증글 작성 방어 로직 개선

## 작업 내용
- 중복 인증글을 작성한 회원 체크 쿼리를 exists 형태로 개선
- 데일리 챌린지 스케줄러에서 삭제 결과를 반환하도록 수정.
- 스케줄러 수정에 따른 테스트 코드 수정 반영
- 사용하지 않는 import 정리
- 기타 불필요한 코드 정리

## 참고 사항

## 관련 이슈
Close #176 
