### PR TITLE
[#186] fix: 펫 대표 프로필 수정 시 대표 프로필 지정 버튼을 누르지 않아도 대표 프로필로 지정

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/member/service/MemberService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/member/service/MemberService.java
@@ -128,16 +128,26 @@ public class MemberService {
 
     @Transactional
     public void updatePet(Member member, PetProfileReq petProfileReq, MultipartFile image){
-        String originUrl = null;
         List<Pet> petList = petRepository.findAll();
         Pet pet = petRepository.findById(petProfileReq.getPetId())
                 .orElseThrow(() -> new Exception404(PET_NOT_FOUND));
+
+        String originUrl = null;
 
         if (!image.isEmpty()) {
             originUrl = amazonS3Service.uploadPetProfileImage(image);
         }
 
+        //원래 대표 프로필인 경우
+        if(pet.getIsSelected()){
+            pet.updatePet(member, petProfileReq, originUrl);
+            pet.updateIsSelected(true);
+            petRepository.save(pet);
+            return;
 
+        }
+
+        //대표 프로필이 아닌 경우
         if(petProfileReq.getIsSelected()){
             checkIsSelected(petList);
             pet.updatePet(member, petProfileReq, originUrl);
@@ -147,6 +157,7 @@ public class MemberService {
 
         pet.updatePet(member, petProfileReq, originUrl);
         petRepository.save(pet);
+
     }
 
     @Transactional


### PR DESCRIPTION
## 요약
펫 대표 프로필 수정 시 대표 프로필 지정 버튼을 누르지 않아도 대표 프로필로 지정

## 작업 내용

## 참고 사항

## 관련 이슈
Close #186 
