### PR TITLE
[#193] fix : 회원탈퇴 시 펫톡 관련 삭제 로직 추가

### DIFF
--- a/src/main/java/com/itoxi/petnuri/domain/member/service/MemberService.java
+++ b/src/main/java/com/itoxi/petnuri/domain/member/service/MemberService.java
@@ -16,6 +16,7 @@ import com.itoxi.petnuri.domain.member.repository.MemberRepository;
 import com.itoxi.petnuri.domain.member.repository.PetRepository;
 import com.itoxi.petnuri.domain.petTalk.entity.PetTalk;
 import com.itoxi.petnuri.domain.petTalk.entity.PetTalkPhoto;
+import com.itoxi.petnuri.domain.petTalk.repository.PetTalkEmotionRepository;
 import com.itoxi.petnuri.domain.petTalk.repository.PetTalkPhotoJpaRepository;
 import com.itoxi.petnuri.domain.petTalk.repository.PetTalkReplyRepository;
 import com.itoxi.petnuri.domain.petTalk.repository.PetTalkRepository;
@@ -53,6 +54,7 @@ public class MemberService {
     private final PetTalkRepository petTalkRepository;
     private final PetTalkReplyRepository petTalkReplyRepository;
     private final PetTalkPhotoJpaRepository petTalkPhotoJpaRepository;
+    private final PetTalkEmotionRepository petTalkEmotionRepository;
     private final RewardChallengeRepository rewardChallengeRepository;
     private final DailyChallengeRepository dailyChallengeRepository;
     private final JwtTokenProvider jwtTokenProvider;
@@ -165,10 +167,12 @@ public class MemberService {
     public void withdraw(Member member, String accessToken) {
         try {
             petTalkReplyRepository.deleteByWriter(member);
+            petTalkEmotionRepository.deleteByMember(member);
             List<PetTalk> petTalkList = petTalkRepository.findAllByWriter(member);
 
             for (PetTalk petTalk : petTalkList) {
                 petTalkReplyRepository.deleteAllByPetTalk(petTalk);
+                petTalkPhotoJpaRepository.deleteAllByPetTalk(petTalk);
             }
 
             petTalkRepository.deleteAll(petTalkList);

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/repository/PetTalkEmotionRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/repository/PetTalkEmotionRepository.java
@@ -17,4 +17,6 @@ public interface PetTalkEmotionRepository extends JpaRepository<PetTalkEmotion, 
     boolean existsByMemberIdAndPetTalkId(Long memberId, Long PetTalkId);
 
     boolean existsByPetTalkIdAndEmoji(Long petTalkId, EmojiType emojiType);
+
+    void deleteByMember(Member member);
 }

--- a/src/main/java/com/itoxi/petnuri/domain/petTalk/repository/PetTalkPhotoJpaRepository.java
+++ b/src/main/java/com/itoxi/petnuri/domain/petTalk/repository/PetTalkPhotoJpaRepository.java
@@ -11,4 +11,6 @@ public interface PetTalkPhotoJpaRepository extends JpaRepository<PetTalkPhoto, L
     List<PetTalkPhoto> findAllByPetTalkIdOrderByIdAsc(Long petTalkId);
 
     Optional<PetTalkPhoto> findTop1ByPetTalkOrderByIdAsc(PetTalk petTalk);
+
+    void deleteAllByPetTalk(PetTalk petTalk);
 }


### PR DESCRIPTION
## 요약
회원탈퇴 시 펫톡 관련 삭제 로직 추가

## 작업 내용

- [x] 펫톡 이모션 삭제 로직추가
- [x] 펫톡 포토 삭제 로직 추가

## 참고 사항
양방향 관련해서 @Ondelete, cascade 가 중복해서 사용되지 않는 것 같음. petTalk emotion에 걸어놓았음에도 foreign key로 인하여 여전히 삭제 오류

## 관련 이슈
Close #193 
